### PR TITLE
feature: add github

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -1,0 +1,24 @@
+name: Setup Nix
+description: Install Nix and setup caching for Nix builds
+runs:
+  using: "composite"
+  steps:
+    - name: Install Nix
+      uses: nixbuild/nix-quick-install-action@v34
+      with:
+        nix_conf: |
+          keep-env-derivations = true
+          keep-outputs = true
+
+    - name: Restore and save Nix store
+      uses: nix-community/cache-nix-action@v6
+      with:
+        primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+        restore-prefixes-first-match: nix-${{ runner.os }}-
+        gc-max-store-size-linux: 2G
+        gc-max-store-size-macos: 2G
+        purge: true
+        purge-prefixes: nix-${{ runner.os }}-
+        purge-created: 0
+        purge-last-accessed: 0
+        purge-primary-key: never

--- a/.github/workflows/pass_cargo_commands.yml
+++ b/.github/workflows/pass_cargo_commands.yml
@@ -1,0 +1,135 @@
+name: Cargo Commands CI
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - src/cli/src/**/*.rs
+      - src/linter/src/**/*.rs
+      - src/flake-generator/src/**/*.rs
+      - src/nix-dispatcher/src/**/*.rs
+      - src/cli/Cargo.toml
+      - src/linter/Cargo.toml
+      - src/flake-generator/Cargo.toml
+      - src/nix-dispatcher/Cargo.toml
+      - Cargo.toml
+      - Cargo.lock
+
+jobs:
+  detect-changes:
+    name: Detect changed crates
+    runs-on: ubuntu-24.04
+    outputs:
+      cli: ${{ steps.filter.outputs.cli }}
+      linter: ${{ steps.filter.outputs.linter }}
+      flake-generator: ${{ steps.filter.outputs.flake-generator }}
+      nix-dispatcher: ${{ steps.filter.outputs.nix-dispatcher }}
+      any-crate: ${{ steps.filter.outputs.any-crate }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Detect changed paths
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            cli:
+              - src/cli/src/**/*.rs
+              - src/cli/Cargo.toml
+            linter:
+              - src/linter/src/**/*.rs
+              - src/linter/Cargo.toml
+            flake-generator:
+              - src/flake-generator/src/**/*.rs
+              - src/flake-generator/Cargo.toml
+            nix-dispatcher:
+              - src/nix-dispatcher/src/**/*.rs
+              - src/nix-dispatcher/Cargo.toml
+            any-crate:
+              - src/*/src/**/*.rs
+              - src/*/Cargo.toml
+              - Cargo.toml
+              - Cargo.lock
+
+  cargo-fmt-and-clippy:
+    name: cargo fmt + clippy
+    runs-on: ubuntu-24.04
+    needs: detect-changes
+    if: needs.detect-changes.outputs.any-crate == 'true'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run cargo fmt
+        run: cargo fmt --all --check
+
+      - name: Run cargo clippy on cli
+        if: needs.detect-changes.outputs.cli == 'true'
+        run: cargo clippy -p lnix --all-targets -- --deny warnings
+
+      - name: Run cargo clippy on linter
+        if: needs.detect-changes.outputs.linter == 'true'
+        run: cargo clippy -p lnix-linter --all-targets -- --deny warnings
+
+      - name: Run cargo clippy on flake-generator
+        if: needs.detect-changes.outputs.flake-generator == 'true'
+        run: cargo clippy -p lnix-flake-generator --all-targets -- --deny warnings
+
+      - name: Run cargo clippy on nix-dispatcher
+        if: needs.detect-changes.outputs.nix-dispatcher == 'true'
+        run: cargo clippy -p lnix-nix-dispatcher --all-targets -- --deny warnings
+
+  cargo-test:
+    name: cargo test
+    runs-on: ubuntu-24.04
+    needs: [detect-changes, cargo-fmt-and-clippy]
+    if: needs.detect-changes.outputs.any-crate == 'true'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run cargo test on cli
+        if: needs.detect-changes.outputs.cli == 'true'
+        run: cargo test -p lnix
+
+      - name: Run cargo test on linter
+        if: needs.detect-changes.outputs.linter == 'true'
+        run: cargo test -p lnix-linter
+
+      - name: Run cargo test on flake-generator
+        if: needs.detect-changes.outputs.flake-generator == 'true'
+        run: cargo test -p lnix-flake-generator
+
+      - name: Run cargo test on nix-dispatcher
+        if: needs.detect-changes.outputs.nix-dispatcher == 'true'
+        run: cargo test -p lnix-nix-dispatcher

--- a/.github/workflows/pass_nix_commands.yml
+++ b/.github/workflows/pass_nix_commands.yml
@@ -1,0 +1,32 @@
+name: Nix Commands CI
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - flake.nix
+      - flake.lock
+
+jobs:
+  nix-flow:
+    name: ${{ matrix.os }} run
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Nix
+        uses: ./.github/actions/setup-nix
+
+      - name: Run nix build
+        run: nix build
+
+      - name: Run nix develop
+        run: nix develop --command echo "Development shell activated successfully"
+
+      - name: Run nix run
+        run: nix run . -- --help

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,179 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  prepare-release:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Validate branch
+        run: |
+          if [ "${{ github.ref }}" != "refs/heads/main" ]; then
+            echo "Error: Release must be run from main branch"
+            exit 1
+          fi
+
+      - name: Get version from Cargo.toml
+        id: version
+        run: |
+          chmod +x scripts/get-version.sh
+          VERSION=$(./scripts/get-version.sh)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Version: $VERSION"
+
+      - name: Check tag does not exist
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            echo "Error: Tag v$VERSION already exists"
+            exit 1
+          fi
+          echo "Tag v$VERSION does not exist, proceeding with release"
+
+  build-x86_64-linux:
+    needs: prepare-release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Nix
+        uses: ./.github/actions/setup-nix
+
+      - name: Build for x86_64-linux
+        run: |
+          nix build .#releasePackages.x86_64-linux.rust_builder
+          cp result/bin/lnix lnix-x86_64-linux
+          chmod +x lnix-x86_64-linux
+
+      - name: Test binary
+        run: |
+          ./lnix-x86_64-linux --version
+          ./lnix-x86_64-linux --help
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lnix-x86_64-linux
+          path: lnix-x86_64-linux
+
+  build-aarch64-linux:
+    needs: prepare-release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Nix
+        uses: ./.github/actions/setup-nix
+
+      - name: Enable aarch64 support
+        run: |
+          mkdir -p ~/.config/nix
+          echo "extra-platforms = aarch64-linux" >> ~/.config/nix/nix.conf
+
+      - name: Build for aarch64-linux
+        run: |
+          nix build .#releasePackages.aarch64-linux.rust_builder
+          cp result/bin/lnix lnix-aarch64-linux
+          chmod +x lnix-aarch64-linux
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lnix-aarch64-linux
+          path: lnix-aarch64-linux
+
+  build-aarch64-darwin:
+    needs: prepare-release
+    runs-on: macos-14
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Nix
+        uses: ./.github/actions/setup-nix
+
+      - name: Build for aarch64-darwin
+        run: |
+          nix build .#releasePackages.aarch64-darwin.rust_builder
+          cp result/bin/lnix lnix-aarch64-darwin
+          chmod +x lnix-aarch64-darwin
+
+      - name: Test binary
+        run: |
+          ./lnix-aarch64-darwin --version
+          ./lnix-aarch64-darwin --help
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lnix-aarch64-darwin
+          path: lnix-aarch64-darwin
+
+  create-release:
+    needs:
+      - prepare-release
+      - build-x86_64-linux
+      - build-aarch64-linux
+      - build-aarch64-darwin
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Prepare binaries
+        env:
+          VERSION: ${{ needs.prepare-release.outputs.version }}
+        run: |
+          mkdir -p release-binaries
+          cp artifacts/lnix-x86_64-linux/lnix-x86_64-linux release-binaries/
+          cp artifacts/lnix-aarch64-linux/lnix-aarch64-linux release-binaries/
+          cp artifacts/lnix-aarch64-darwin/lnix-aarch64-darwin release-binaries/
+          chmod +x release-binaries/*
+          ls -lh release-binaries/
+
+      - name: Create and push tag
+        env:
+          VERSION: ${{ needs.prepare-release.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "v$VERSION"
+          git push origin "v$VERSION"
+
+      - name: Create GitHub Release
+        env:
+          VERSION: ${{ needs.prepare-release.outputs.version }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          cd release-binaries
+
+          gh release create "v$VERSION" \
+            --title "Release v$VERSION" \
+            --generate-notes \
+            lnix-x86_64-linux \
+            lnix-aarch64-linux \
+            lnix-aarch64-darwin
+
+          echo "GitHub Release v$VERSION created successfully"


### PR DESCRIPTION
This pull request introduces a comprehensive set of GitHub Actions workflows to automate CI and release processes for the project, with a strong focus on both Rust and Nix-based builds. The changes add robust workflows for formatting, linting, testing, and building across multiple platforms, as well as a reusable Nix setup action. Additionally, a release workflow is implemented to automate version tagging and publishing release binaries.

**CI/CD Workflow Enhancements:**

* Added a new workflow `.github/workflows/pass_cargo_commands.yml` to run `cargo fmt`, `cargo clippy`, and `cargo test` conditionally on Rust crate changes, with per-crate granularity for `cli`, `linter`, `flake-generator`, and `nix-dispatcher` crates.
* Introduced `.github/workflows/pass_nix_commands.yml` to run Nix-based build, develop, and run commands on both Ubuntu and macOS, ensuring Nix expressions and development environments are validated in CI.

**Reusable Nix Setup Action:**

* Added a composite action `.github/actions/setup-nix/action.yml` to install Nix and configure caching for Nix builds, enabling consistent Nix environment setup across workflows.

**Automated Release Process:**

* Implemented a release workflow `.github/workflows/release.yml` that:
  - Validates the release branch and version,
  - Builds release binaries for `x86_64-linux`, `aarch64-linux`, and `aarch64-darwin` using Nix,
  - Uploads artifacts,
  - Tags the release, and
  - Publishes a GitHub Release with generated notes and attached binaries.