### PR TITLE
Implement version pinning with flake.nix integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,6 +391,8 @@ dependencies = [
 name = "lnix-nix-dispatcher"
 version = "1.0.0"
 dependencies = [
+ "serde",
+ "serde_json",
  "thiserror",
 ]
 

--- a/examples/python/lazynix.yaml
+++ b/examples/python/lazynix.yaml
@@ -2,9 +2,10 @@ devShell:
   allowUnfree: true
   package:
     stable:
-      - python312
-      - uv
+      - name: python312
+      - name: uv
     unstable: []
+    pinned: []
   shellHook:
     - "echo Python $(python --version) ready!"
     - "echo uv $(uv --version) ready!"

--- a/src/cli/src/cli_parser.rs
+++ b/src/cli/src/cli_parser.rs
@@ -85,4 +85,22 @@ pub enum Commands {
         #[arg(long)]
         arch: Option<String>,
     },
+
+    /// Search for available package versions via nix-versions
+    Search {
+        /// Package name to search for
+        package_name: String,
+
+        /// Version constraint (semver syntax, e.g., ">=1.20,<1.22")
+        #[arg(short, long)]
+        version: Option<String>,
+
+        /// Output results as JSON
+        #[arg(short, long)]
+        json: bool,
+
+        /// Show only the latest matching version
+        #[arg(short = '1', long)]
+        one: bool,
+    },
 }

--- a/src/cli/src/commands/lint.rs
+++ b/src/cli/src/commands/lint.rs
@@ -23,10 +23,10 @@ pub fn execute(config_dir: &str, verbose: bool, arch: Option<&str>) -> Result<bo
     let mut packages: Vec<String> = Vec::new();
 
     // Add stable packages
-    packages.extend(config.dev_shell.package.stable.iter().cloned());
+    packages.extend(config.dev_shell.package.stable.iter().map(|e| e.name.clone()));
 
     // Add unstable packages
-    packages.extend(config.dev_shell.package.unstable.iter().cloned());
+    packages.extend(config.dev_shell.package.unstable.iter().map(|e| e.name.clone()));
 
     if packages.is_empty() {
         println!("No packages to validate.");

--- a/src/cli/src/commands/lint.rs
+++ b/src/cli/src/commands/lint.rs
@@ -23,10 +23,24 @@ pub fn execute(config_dir: &str, verbose: bool, arch: Option<&str>) -> Result<bo
     let mut packages: Vec<String> = Vec::new();
 
     // Add stable packages
-    packages.extend(config.dev_shell.package.stable.iter().map(|e| e.name.clone()));
+    packages.extend(
+        config
+            .dev_shell
+            .package
+            .stable
+            .iter()
+            .map(|e| e.name.clone()),
+    );
 
     // Add unstable packages
-    packages.extend(config.dev_shell.package.unstable.iter().map(|e| e.name.clone()));
+    packages.extend(
+        config
+            .dev_shell
+            .package
+            .unstable
+            .iter()
+            .map(|e| e.name.clone()),
+    );
 
     if packages.is_empty() {
         println!("No packages to validate.");

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -11,7 +11,8 @@ use error::Result;
 use lazynix_settings_yaml::Settings;
 use lnix_flake_generator::{LazyNixParser, render_flake, validate_config};
 use lnix_nix_dispatcher::{
-    run_flake_update, run_nix_develop, run_nix_develop_command, run_nix_test, run_task_in_nix_env,
+    resolve_version, run_flake_update, run_nix_develop, run_nix_develop_command, run_nix_test,
+    run_task_in_nix_env,
 };
 use std::fs;
 use std::path::Path;
@@ -140,7 +141,7 @@ fn cmd_develop(config_dir: &Path, update_lock: bool) -> Result<()> {
     // Step 2: Read and parse config using LazyNixParser
     println!("Reading configuration from {}...", config_dir.display());
     let parser = LazyNixParser::new(config_dir.to_path_buf());
-    let config = parser.read_config()?;
+    let mut config = parser.read_config()?;
 
     // Step 3: Validate config
     println!("Validating configuration...");
@@ -148,6 +149,9 @@ fn cmd_develop(config_dir: &Path, update_lock: bool) -> Result<()> {
 
     // Step 3.5: Validate env configuration
     env_validator::validate_env_config(&config.dev_shell.env, config_dir)?;
+
+    // Step 3.6: Resolve pinned package versions
+    resolve_pinned_packages(&parser, &mut config)?;
 
     // Step 4: Generate flake.nix
     println!("Generating flake.nix...");
@@ -179,7 +183,7 @@ fn cmd_test(config_dir: &Path, update_lock: bool) -> Result<()> {
     // Step 2: Read and parse config using LazyNixParser
     println!("Reading configuration from {}...", config_dir.display());
     let parser = LazyNixParser::new(config_dir.to_path_buf());
-    let config = parser.read_config()?;
+    let mut config = parser.read_config()?;
 
     // Step 3: Validate config
     println!("Validating configuration...");
@@ -187,6 +191,9 @@ fn cmd_test(config_dir: &Path, update_lock: bool) -> Result<()> {
 
     // Step 3.5: Validate env configuration
     env_validator::validate_env_config(&config.dev_shell.env, config_dir)?;
+
+    // Step 3.6: Resolve pinned package versions
+    resolve_pinned_packages(&parser, &mut config)?;
 
     // Step 4: Validate test attribute is not empty
     if config.dev_shell.test.is_empty() {
@@ -246,7 +253,7 @@ fn cmd_run(
         // Step 2: Read and parse config using LazyNixParser
         println!("Reading configuration from {}...", config_dir.display());
         let parser = LazyNixParser::new(config_dir.to_path_buf());
-        let config = parser.read_config()?;
+        let mut config = parser.read_config()?;
 
         // Step 3: Validate config
         println!("Validating configuration...");
@@ -254,6 +261,9 @@ fn cmd_run(
 
         // Step 3.5: Validate env configuration
         env_validator::validate_env_config(&config.dev_shell.env, config_dir)?;
+
+        // Step 3.6: Resolve pinned package versions
+        resolve_pinned_packages(&parser, &mut config)?;
 
         // Step 4: Generate flake.nix
         println!("Generating flake.nix...");
@@ -311,4 +321,32 @@ fn cmd_task(config_dir: &Path, task_name: String, args: Vec<String>) -> Result<i
     // Step 7: Execute task in nix develop environment
     let exit_code = run_task_in_nix_env(commands)?;
     Ok(exit_code)
+}
+
+fn resolve_pinned_packages(
+    parser: &LazyNixParser,
+    config: &mut lnix_flake_generator::Config,
+) -> Result<bool> {
+    let mut resolved_any = false;
+    for entry in &mut config.dev_shell.package.pinned {
+        if entry.resolved_commit.is_some() && entry.resolved_attr.is_some() {
+            continue;
+        }
+        println!(
+            "Resolving version for {} @ {}...",
+            entry.name, entry.version
+        );
+        let resolved = resolve_version(&entry.name, &entry.version)?;
+        entry.resolved_commit = Some(resolved.commit);
+        entry.resolved_attr = Some(resolved.attr);
+        resolved_any = true;
+    }
+
+    if resolved_any {
+        let yaml_content = serde_yaml::to_string(&config)?;
+        parser.write_config(&yaml_content)?;
+        println!("Updated lazynix.yaml with resolved versions");
+    }
+
+    Ok(resolved_any)
 }

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -12,7 +12,7 @@ use lazynix_settings_yaml::Settings;
 use lnix_flake_generator::{LazyNixParser, render_flake, validate_config};
 use lnix_nix_dispatcher::{
     resolve_version, run_flake_update, run_nix_develop, run_nix_develop_command, run_nix_test,
-    run_task_in_nix_env,
+    run_task_in_nix_env, search_versions,
 };
 use std::fs;
 use std::path::Path;
@@ -77,6 +77,12 @@ fn run() -> Result<()> {
                 std::process::exit(1);
             }
         }
+        Commands::Search {
+            package_name,
+            version,
+            json,
+            one,
+        } => cmd_search(&package_name, version.as_deref(), json, one)?,
     }
 
     Ok(())
@@ -349,4 +355,15 @@ fn resolve_pinned_packages(
     }
 
     Ok(resolved_any)
+}
+
+fn cmd_search(
+    package_name: &str,
+    version: Option<&str>,
+    json: bool,
+    one: bool,
+) -> Result<()> {
+    let output = search_versions(package_name, version, json, one)?;
+    print!("{}", output);
+    Ok(())
 }

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -357,12 +357,7 @@ fn resolve_pinned_packages(
     Ok(resolved_any)
 }
 
-fn cmd_search(
-    package_name: &str,
-    version: Option<&str>,
-    json: bool,
-    one: bool,
-) -> Result<()> {
+fn cmd_search(package_name: &str, version: Option<&str>, json: bool, one: bool) -> Result<()> {
     let output = search_versions(package_name, version, json, one)?;
     print!("{}", output);
     Ok(())

--- a/src/cli/tests/common/fixtures.rs
+++ b/src/cli/tests/common/fixtures.rs
@@ -5,8 +5,9 @@ pub fn minimal_config() -> String {
   allowUnfree: true
   package:
     stable:
-      - bash
+      - name: bash
     unstable: []
+    pinned: []
   shellHook: []
 "#
     .to_string()
@@ -22,6 +23,7 @@ pub fn config_with_packages(stable: &[&str], unstable: &[&str]) -> String {
 {}
     unstable:
 {}
+    pinned: []
   shellHook: []
 "#,
         if stable.is_empty() {
@@ -29,7 +31,7 @@ pub fn config_with_packages(stable: &[&str], unstable: &[&str]) -> String {
         } else {
             stable
                 .iter()
-                .map(|p| format!("      - {}", p))
+                .map(|p| format!("      - name: {}", p))
                 .collect::<Vec<_>>()
                 .join("\n")
         },
@@ -38,7 +40,7 @@ pub fn config_with_packages(stable: &[&str], unstable: &[&str]) -> String {
         } else {
             unstable
                 .iter()
-                .map(|p| format!("      - {}", p))
+                .map(|p| format!("      - name: {}", p))
                 .collect::<Vec<_>>()
                 .join("\n")
         }
@@ -53,7 +55,8 @@ pub fn config_with_test_commands(tests: &[&str]) -> String {
   allowUnfree: true
   package:
     stable:
-      - bash
+      - name: bash
+    pinned: []
   test:
 {}
 "#,
@@ -85,7 +88,8 @@ pub fn config_with_tasks(tasks: &[(&str, Vec<&str>, Option<&str>)]) -> String {
   allowUnfree: true
   package:
     stable:
-      - bash
+      - name: bash
+    pinned: []
   task:
 {}
 "#,
@@ -100,7 +104,7 @@ pub fn invalid_yaml_config() -> String {
   allowUnfree: true
   package:
     stable:
-      - hello
+      - name: hello
     - this is invalid yaml syntax
 "#
     .to_string()

--- a/src/flake-generator/src/config.rs
+++ b/src/flake-generator/src/config.rs
@@ -566,10 +566,7 @@ devShell:
         let config: Config = serde_yaml::from_str(yaml).unwrap();
         let result = validate_config(&config);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("empty version"));
+        assert!(result.unwrap_err().to_string().contains("empty version"));
     }
 
     #[test]

--- a/src/flake-generator/src/config.rs
+++ b/src/flake-generator/src/config.rs
@@ -36,14 +36,38 @@ pub struct DevShell {
     pub shell_alias: Vec<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Package {
     #[serde(default)]
-    pub stable: Vec<String>,
+    pub stable: Vec<PackageEntry>,
 
     #[serde(default)]
-    pub unstable: Vec<String>,
+    pub unstable: Vec<PackageEntry>,
+
+    #[serde(default)]
+    pub pinned: Vec<PinnedPackageEntry>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PackageEntry {
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PinnedPackageEntry {
+    pub name: String,
+    pub version: String,
+
+    /// nixpkgs commit hash. Auto-resolved via nix-versions.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolved_commit: Option<String>,
+
+    /// Nix attribute path (e.g., "go_1_21"). Auto-resolved via nix-versions.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolved_attr: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -87,21 +111,37 @@ fn is_valid_task_name(name: &str) -> bool {
 
 pub fn validate_config(config: &Config) -> Result<()> {
     // Validate stable package names
-    for pkg in &config.dev_shell.package.stable {
-        if !is_valid_package_name(pkg) {
+    for entry in &config.dev_shell.package.stable {
+        if !is_valid_package_name(&entry.name) {
             return Err(Error::Validation(format!(
                 "Invalid stable package name: {}. Package names should contain only alphanumeric characters, hyphens, underscores, and dots (for nested attributes like python312Packages.pip)",
-                pkg
+                entry.name
             )));
         }
     }
 
     // Validate unstable package names
-    for pkg in &config.dev_shell.package.unstable {
-        if !is_valid_package_name(pkg) {
+    for entry in &config.dev_shell.package.unstable {
+        if !is_valid_package_name(&entry.name) {
             return Err(Error::Validation(format!(
                 "Invalid unstable package name: {}. Package names should contain only alphanumeric characters, hyphens, underscores, and dots (for nested attributes like python312Packages.pip)",
-                pkg
+                entry.name
+            )));
+        }
+    }
+
+    // Validate pinned package entries
+    for entry in &config.dev_shell.package.pinned {
+        if !is_valid_package_name(&entry.name) {
+            return Err(Error::Validation(format!(
+                "Invalid pinned package name: {}. Package names should contain only alphanumeric characters, hyphens, underscores, and dots (for nested attributes like python312Packages.pip)",
+                entry.name
+            )));
+        }
+        if entry.version.is_empty() {
+            return Err(Error::Validation(format!(
+                "Pinned package '{}' has an empty version. A version must be specified.",
+                entry.name
             )));
         }
     }
@@ -128,7 +168,10 @@ pub fn validate_config(config: &Config) -> Result<()> {
     }
 
     // Check that at least some configuration is provided
-    if config.dev_shell.package.stable.is_empty() && config.dev_shell.package.unstable.is_empty() {
+    if config.dev_shell.package.stable.is_empty()
+        && config.dev_shell.package.unstable.is_empty()
+        && config.dev_shell.package.pinned.is_empty()
+    {
         eprintln!("Warning: No packages specified in lazynix.yaml");
     }
 
@@ -146,7 +189,7 @@ devShell:
   allowUnfree: false
   package:
     stable:
-      - bash
+      - name: bash
   env:
     dotenv:
       - .env
@@ -172,7 +215,7 @@ devShell:
   allowUnfree: false
   package:
     stable:
-      - bash
+      - name: bash
 "#;
         let config: Config = serde_yaml::from_str(yaml).unwrap();
         assert!(config.dev_shell.env.is_none());
@@ -185,7 +228,7 @@ devShell:
   allowUnfree: false
   package:
     stable:
-      - bash
+      - name: bash
   env:
     dotenv:
       - .env
@@ -208,7 +251,7 @@ devShell:
   allowUnfree: false
   package:
     stable:
-      - bash
+      - name: bash
   env:
     envvar:
       - name: PYTHONPATH
@@ -235,7 +278,7 @@ devShell:
   allowUnfree: false
   package:
     stable:
-      - bash
+      - name: bash
   env:
     dotenv: []
     envvar: []
@@ -255,7 +298,7 @@ devShell:
   allowUnfree: false
   package:
     stable:
-      - bash
+      - name: bash
   test:
     - pytest
     - cargo test
@@ -275,7 +318,7 @@ devShell:
   allowUnfree: false
   package:
     stable:
-      - bash
+      - name: bash
 "#;
         let config: Config = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(config.dev_shell.test.len(), 0);
@@ -289,7 +332,7 @@ devShell:
   allowUnfree: false
   package:
     stable:
-      - bash
+      - name: bash
   test: []
 "#;
         let config: Config = serde_yaml::from_str(yaml).unwrap();
@@ -304,7 +347,7 @@ devShell:
   allowUnfree: false
   package:
     stable:
-      - bash
+      - name: bash
   task:
     sync:
       description: "Sync dependencies"
@@ -342,7 +385,7 @@ devShell:
   allowUnfree: false
   package:
     stable:
-      - bash
+      - name: bash
 "#;
         let config: Config = serde_yaml::from_str(yaml).unwrap();
         assert!(config.dev_shell.task.is_none());
@@ -355,7 +398,7 @@ devShell:
   allowUnfree: false
   package:
     stable:
-      - bash
+      - name: bash
   task:
     hello:
       commands:
@@ -378,7 +421,7 @@ devShell:
   allowUnfree: false
   package:
     stable:
-      - bash
+      - name: bash
   task:
     my-task_123:
       description: "Valid task"
@@ -396,7 +439,7 @@ devShell:
   allowUnfree: false
   package:
     stable:
-      - bash
+      - name: bash
   task:
     invalid@task:
       commands:
@@ -418,7 +461,7 @@ devShell:
   allowUnfree: false
   package:
     stable:
-      - bash
+      - name: bash
   task:
     empty-task:
       description: "Empty command"
@@ -439,7 +482,7 @@ devShell:
 devShell:
   package:
     stable:
-      - bash
+      - name: bash
   shellAlias:
     - ./aliases.sh
     - ~/.my_aliases
@@ -456,9 +499,97 @@ devShell:
 devShell:
   package:
     stable:
-      - bash
+      - name: bash
 "#;
         let config: Config = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(config.dev_shell.shell_alias.len(), 0);
+    }
+
+    #[test]
+    fn test_deserialize_yaml_with_pinned() {
+        let yaml = r#"
+devShell:
+  allowUnfree: false
+  package:
+    stable:
+      - name: bash
+    pinned:
+      - name: go
+        version: "1.21.13"
+        resolvedCommit: "5ed6275"
+        resolvedAttr: "go_1_21"
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.dev_shell.package.pinned.len(), 1);
+
+        let pinned = &config.dev_shell.package.pinned[0];
+        assert_eq!(pinned.name, "go");
+        assert_eq!(pinned.version, "1.21.13");
+        assert_eq!(pinned.resolved_commit.as_deref(), Some("5ed6275"));
+        assert_eq!(pinned.resolved_attr.as_deref(), Some("go_1_21"));
+    }
+
+    #[test]
+    fn test_deserialize_yaml_with_pinned_unresolved() {
+        let yaml = r#"
+devShell:
+  allowUnfree: false
+  package:
+    stable:
+      - name: bash
+    pinned:
+      - name: go
+        version: "1.21.13"
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.dev_shell.package.pinned.len(), 1);
+
+        let pinned = &config.dev_shell.package.pinned[0];
+        assert_eq!(pinned.name, "go");
+        assert_eq!(pinned.version, "1.21.13");
+        assert!(pinned.resolved_commit.is_none());
+        assert!(pinned.resolved_attr.is_none());
+    }
+
+    #[test]
+    fn test_validate_pinned_empty_version() {
+        let yaml = r#"
+devShell:
+  allowUnfree: false
+  package:
+    stable:
+      - name: bash
+    pinned:
+      - name: go
+        version: ""
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let result = validate_config(&config);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("empty version"));
+    }
+
+    #[test]
+    fn test_validate_pinned_invalid_name() {
+        let yaml = r#"
+devShell:
+  allowUnfree: false
+  package:
+    stable:
+      - name: bash
+    pinned:
+      - name: "invalid package!"
+        version: "1.0"
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let result = validate_config(&config);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Invalid pinned package name"));
     }
 }

--- a/src/flake-generator/src/generator.rs
+++ b/src/flake-generator/src/generator.rs
@@ -1,4 +1,4 @@
-use crate::config::{Config, EnvVar};
+use crate::config::{Config, EnvVar, PinnedPackageEntry};
 
 fn is_absolute_path(path: &str) -> bool {
     path.starts_with('/')
@@ -114,11 +114,40 @@ fi"#,
     )
 }
 
+fn normalize_version(version: &str) -> String {
+    version.replace('.', "-")
+}
+
+fn pinned_input_name(entry: &PinnedPackageEntry) -> String {
+    format!(
+        "nixpkgs--{}--{}",
+        entry.name,
+        normalize_version(&entry.version)
+    )
+}
+
+fn pinned_binding_name(entry: &PinnedPackageEntry) -> String {
+    format!(
+        "pinnedPkgs-{}-{}",
+        entry.name,
+        normalize_version(&entry.version)
+    )
+}
+
 pub fn render_flake(config: &Config, override_stable_package: Option<&str>) -> String {
     let allow_unfree = config.dev_shell.allow_unfree;
 
     // Determine stable nixpkgs URL (use override if provided, otherwise default)
     let stable_url = override_stable_package.unwrap_or("github:NixOS/nixpkgs/nixos-25.11");
+
+    // Collect resolved pinned entries
+    let resolved_pinned: Vec<&PinnedPackageEntry> = config
+        .dev_shell
+        .package
+        .pinned
+        .iter()
+        .filter(|p| p.resolved_commit.is_some() && p.resolved_attr.is_some())
+        .collect();
 
     // Format stable packages
     let stable_packages = if config.dev_shell.package.stable.is_empty() {
@@ -129,7 +158,7 @@ pub fn render_flake(config: &Config, override_stable_package: Option<&str>) -> S
             .package
             .stable
             .iter()
-            .map(|pkg| format!("            stablePackages.{}", pkg))
+            .map(|entry| format!("            stablePackages.{}", entry.name))
             .collect::<Vec<_>>()
             .join("\n")
     };
@@ -143,20 +172,50 @@ pub fn render_flake(config: &Config, override_stable_package: Option<&str>) -> S
             .package
             .unstable
             .iter()
-            .map(|pkg| format!("            unstablePackages.{}", pkg))
+            .map(|entry| format!("            unstablePackages.{}", entry.name))
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+
+    // Format pinned packages
+    let pinned_packages = if resolved_pinned.is_empty() {
+        String::new()
+    } else {
+        resolved_pinned
+            .iter()
+            .map(|entry| {
+                let binding = pinned_binding_name(entry);
+                let attr = entry.resolved_attr.as_ref().unwrap();
+                format!("            {}.{}", binding, attr)
+            })
             .collect::<Vec<_>>()
             .join("\n")
     };
 
     // Combine package lists
-    let build_inputs = match (!stable_packages.is_empty(), !unstable_packages.is_empty()) {
-        (true, true) => format!(
-            "            # Stable packages\n{}\n            # Unstable packages\n{}",
-            stable_packages, unstable_packages
-        ),
-        (true, false) => format!("            # Stable packages\n{}", stable_packages),
-        (false, true) => format!("            # Unstable packages\n{}", unstable_packages),
-        (false, false) => String::from("            # No packages specified"),
+    let mut build_input_parts = Vec::new();
+    if !stable_packages.is_empty() {
+        build_input_parts.push(format!(
+            "            # Stable packages\n{}",
+            stable_packages
+        ));
+    }
+    if !unstable_packages.is_empty() {
+        build_input_parts.push(format!(
+            "            # Unstable packages\n{}",
+            unstable_packages
+        ));
+    }
+    if !pinned_packages.is_empty() {
+        build_input_parts.push(format!(
+            "            # Pinned packages\n{}",
+            pinned_packages
+        ));
+    }
+    let build_inputs = if build_input_parts.is_empty() {
+        String::from("            # No packages specified")
+    } else {
+        build_input_parts.join("\n")
     };
 
     // Format dotenv loading
@@ -222,6 +281,78 @@ fi"#,
 
     let shell_hook = shell_hook_parts.join("\n\n");
 
+    // Build pinned inputs section
+    let pinned_inputs = if resolved_pinned.is_empty() {
+        String::new()
+    } else {
+        resolved_pinned
+            .iter()
+            .map(|entry| {
+                let input_name = pinned_input_name(entry);
+                let commit = entry.resolved_commit.as_ref().unwrap();
+                format!("    {}.url = \"github:NixOS/nixpkgs/{}\";", input_name, commit)
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+
+    // Build pinned output params
+    let pinned_output_params = if resolved_pinned.is_empty() {
+        String::new()
+    } else {
+        let params = resolved_pinned
+            .iter()
+            .map(|entry| pinned_input_name(entry))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!(", {}", params)
+    };
+
+    // Build pinned let bindings
+    let pinned_let_bindings = if resolved_pinned.is_empty() {
+        String::new()
+    } else {
+        resolved_pinned
+            .iter()
+            .map(|entry| {
+                let binding = pinned_binding_name(entry);
+                let input_name = pinned_input_name(entry);
+                format!(
+                    "        {} = import {} {{\n          inherit system;\n          config.allowUnfree = {};\n        }};",
+                    binding, input_name, allow_unfree
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+
+    // Build inputs section
+    let mut inputs_lines = vec![
+        format!("    nixpkgs.url = \"{}\";", stable_url),
+        "    nixpkgs-unstable.url = \"github:NixOS/nixpkgs/nixos-unstable\";".to_string(),
+        "    flake-utils.url = \"github:numtide/flake-utils\";".to_string(),
+    ];
+    if !pinned_inputs.is_empty() {
+        inputs_lines.push(pinned_inputs);
+    }
+    let inputs_section = inputs_lines.join("\n");
+
+    // Build let bindings section
+    let mut let_bindings = vec![
+        format!(
+            "        stablePackages = import nixpkgs {{\n          inherit system;\n          config.allowUnfree = {};\n        }};",
+            allow_unfree
+        ),
+        format!(
+            "        unstablePackages = import nixpkgs-unstable {{\n          inherit system;\n          config.allowUnfree = {};\n        }};",
+            allow_unfree
+        ),
+    ];
+    if !pinned_let_bindings.is_empty() {
+        let_bindings.push(pinned_let_bindings);
+    }
+    let let_section = let_bindings.join("\n");
+
     format!(
         r#"# Generated by LazyNix - DO NOT EDIT MANUALLY
 # This file is automatically generated from lazynix.yaml
@@ -231,22 +362,13 @@ fi"#,
   description = "DevShell generated by LazyNix";
 
   inputs = {{
-    nixpkgs.url = "{}";
-    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
+{}
   }};
 
-  outputs = {{ self, nixpkgs, nixpkgs-unstable, flake-utils }}:
+  outputs = {{ self, nixpkgs, nixpkgs-unstable, flake-utils{} }}:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        stablePackages = import nixpkgs {{
-          inherit system;
-          config.allowUnfree = {};
-        }};
-        unstablePackages = import nixpkgs-unstable {{
-          inherit system;
-          config.allowUnfree = {};
-        }};
+{}
       in
       {{
         devShells.default = stablePackages.mkShell {{
@@ -262,24 +384,35 @@ fi"#,
     );
 }}
 "#,
-        stable_url, allow_unfree, allow_unfree, build_inputs, shell_hook
+        inputs_section,
+        pinned_output_params,
+        let_section,
+        build_inputs,
+        shell_hook
     )
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{Config, DevShell, Env, EnvVar, Package};
+    use crate::config::{Config, DevShell, Env, EnvVar, Package, PackageEntry, PinnedPackageEntry};
 
     // Test fixtures and helpers
+
+    fn pkg(name: &str) -> PackageEntry {
+        PackageEntry {
+            name: name.to_string(),
+        }
+    }
 
     fn create_default_config() -> Config {
         Config {
             dev_shell: DevShell {
                 allow_unfree: true,
                 package: Package {
-                    stable: vec!["bash".to_string()],
+                    stable: vec![pkg("bash")],
                     unstable: vec![],
+                    pinned: vec![],
                 },
                 shell_hook: vec![],
                 env: None,
@@ -296,10 +429,10 @@ mod tests {
         config
     }
 
-    fn create_config_with_packages(stable: Vec<String>, unstable: Vec<String>) -> Config {
+    fn create_config_with_packages(stable: Vec<&str>, unstable: Vec<&str>) -> Config {
         let mut config = create_default_config();
-        config.dev_shell.package.stable = stable;
-        config.dev_shell.package.unstable = unstable;
+        config.dev_shell.package.stable = stable.into_iter().map(pkg).collect();
+        config.dev_shell.package.unstable = unstable.into_iter().map(pkg).collect();
         config
     }
 
@@ -320,10 +453,7 @@ mod tests {
 
     #[test]
     fn test_render_flake_with_packages() {
-        let mut config = create_config_with_packages(
-            vec!["python312".to_string(), "gcc".to_string()],
-            vec!["rust-analyzer".to_string()],
-        );
+        let mut config = create_config_with_packages(vec!["python312", "gcc"], vec!["rust-analyzer"]);
         config.dev_shell.shell_hook = vec!["echo Hello".to_string()];
 
         let flake = render_flake(&config, None);
@@ -345,7 +475,7 @@ mod tests {
 
     #[test]
     fn test_render_flake_with_override_stable_package() {
-        let config = create_config_with_packages(vec!["python312".to_string()], vec![]);
+        let config = create_config_with_packages(vec!["python312"], vec![]);
 
         let custom_url = "github:NixOS/nixpkgs/nixos-25.06";
         let flake = render_flake(&config, Some(custom_url));
@@ -357,7 +487,7 @@ mod tests {
 
     #[test]
     fn test_render_flake_without_override_uses_default() {
-        let config = create_config_with_packages(vec!["python312".to_string()], vec![]);
+        let config = create_config_with_packages(vec!["python312"], vec![]);
 
         let flake = render_flake(&config, None);
 
@@ -493,7 +623,7 @@ mod tests {
         // Verify envvar export
         assert!(flake.contains("export MY_VAR=hello"));
 
-        // Verify order: dotenv → envvar → user shellHook
+        // Verify order: dotenv -> envvar -> user shellHook
         let dotenv_pos = flake.find("$PWD/config/.env").unwrap();
         let envvar_pos = flake.find("export MY_VAR").unwrap();
         let user_hook_pos = flake.find("echo Hello").unwrap();
@@ -549,12 +679,10 @@ mod tests {
         ];
         let script = render_test_execution(&tests);
 
-        // すべてのコマンドが含まれることを確認
         assert!(script.contains("pytest"));
         assert!(script.contains("cargo test"));
         assert!(script.contains("npm run test"));
 
-        // all-run 方式の確認
         assert!(script.contains("for test_cmd in"));
         assert!(script.contains("bash -c"));
         assert!(script.contains("Test Results:"));
@@ -567,7 +695,6 @@ mod tests {
 
         let flake = render_flake(&config, None);
 
-        // テスト実行ロジックが含まれていることを確認
         assert!(flake.contains("if [ \"$LAZYNIX_TEST_MODE\" = \"1\" ]"));
         assert!(flake.contains("Running tests"));
         assert!(flake.contains("pytest"));
@@ -578,11 +705,10 @@ mod tests {
 
     #[test]
     fn test_render_flake_without_test() {
-        let config = create_default_config(); // test は空
+        let config = create_default_config();
 
         let flake = render_flake(&config, None);
 
-        // テスト実行ロジックが含まれないことを確認
         assert!(!flake.contains("LAZYNIX_TEST_MODE"));
         assert!(!flake.contains("TESTS_FAILED"));
         assert!(flake.contains("Welcome to LazyNix DevShell!"));
@@ -660,7 +786,7 @@ mod tests {
 
         let flake = render_flake(&config, None);
 
-        // Verify order: dotenv → envvar → shell_alias → user hook
+        // Verify order: dotenv -> envvar -> shell_alias -> user hook
         let dotenv_pos = flake.find("Load dotenv").unwrap();
         let envvar_pos = flake.find("export TEST=").unwrap();
         let alias_pos = flake.find("Load shell aliases").unwrap();
@@ -676,5 +802,62 @@ mod tests {
         // Test tilde expansion
         assert_eq!(resolve_path("~/foo"), "$HOME/foo");
         assert_eq!(resolve_path("~/.aliases"), "$HOME/.aliases");
+    }
+
+    #[test]
+    fn test_render_flake_with_pinned_packages() {
+        let mut config = create_default_config();
+        config.dev_shell.package.pinned = vec![PinnedPackageEntry {
+            name: "go".to_string(),
+            version: "1.21.13".to_string(),
+            resolved_commit: Some("e607cb5".to_string()),
+            resolved_attr: Some("go_1_21".to_string()),
+        }];
+
+        let flake = render_flake(&config, None);
+
+        // Verify pinned input
+        assert!(flake.contains("nixpkgs--go--1-21-13.url = \"github:NixOS/nixpkgs/e607cb5\";"));
+        // Verify pinned output param
+        assert!(flake.contains("nixpkgs--go--1-21-13"));
+        // Verify pinned let binding
+        assert!(flake.contains("pinnedPkgs-go-1-21-13 = import nixpkgs--go--1-21-13"));
+        // Verify pinned package in buildInputs
+        assert!(flake.contains("pinnedPkgs-go-1-21-13.go_1_21"));
+    }
+
+    #[test]
+    fn test_render_flake_with_unresolved_pinned_skipped() {
+        let mut config = create_default_config();
+        config.dev_shell.package.pinned = vec![PinnedPackageEntry {
+            name: "go".to_string(),
+            version: "1.21.13".to_string(),
+            resolved_commit: None,
+            resolved_attr: None,
+        }];
+
+        let flake = render_flake(&config, None);
+
+        // Unresolved pinned should be skipped
+        assert!(!flake.contains("nixpkgs--go--1-21-13"));
+        assert!(!flake.contains("pinnedPkgs-go"));
+    }
+
+    #[test]
+    fn test_normalize_version() {
+        assert_eq!(normalize_version("1.21.13"), "1-21-13");
+        assert_eq!(normalize_version("3.12"), "3-12");
+        assert_eq!(normalize_version("1"), "1");
+    }
+
+    #[test]
+    fn test_pinned_input_name() {
+        let entry = PinnedPackageEntry {
+            name: "go".to_string(),
+            version: "1.21.13".to_string(),
+            resolved_commit: None,
+            resolved_attr: None,
+        };
+        assert_eq!(pinned_input_name(&entry), "nixpkgs--go--1-21-13");
     }
 }

--- a/src/flake-generator/src/generator.rs
+++ b/src/flake-generator/src/generator.rs
@@ -290,7 +290,10 @@ fi"#,
             .map(|entry| {
                 let input_name = pinned_input_name(entry);
                 let commit = entry.resolved_commit.as_ref().unwrap();
-                format!("    {}.url = \"github:NixOS/nixpkgs/{}\";", input_name, commit)
+                format!(
+                    "    {}.url = \"github:NixOS/nixpkgs/{}\";",
+                    input_name, commit
+                )
             })
             .collect::<Vec<_>>()
             .join("\n")
@@ -384,11 +387,7 @@ fi"#,
     );
 }}
 "#,
-        inputs_section,
-        pinned_output_params,
-        let_section,
-        build_inputs,
-        shell_hook
+        inputs_section, pinned_output_params, let_section, build_inputs, shell_hook
     )
 }
 
@@ -453,7 +452,8 @@ mod tests {
 
     #[test]
     fn test_render_flake_with_packages() {
-        let mut config = create_config_with_packages(vec!["python312", "gcc"], vec!["rust-analyzer"]);
+        let mut config =
+            create_config_with_packages(vec!["python312", "gcc"], vec!["rust-analyzer"]);
         config.dev_shell.shell_hook = vec!["echo Hello".to_string()];
 
         let flake = render_flake(&config, None);

--- a/src/flake-generator/src/lib.rs
+++ b/src/flake-generator/src/lib.rs
@@ -7,7 +7,10 @@ mod package_validator;
 mod parser;
 
 // Public API
-pub use config::{validate_config, Config, DevShell, Env, EnvVar, Package, TaskDef};
+pub use config::{
+    validate_config, Config, DevShell, Env, EnvVar, Package, PackageEntry, PinnedPackageEntry,
+    TaskDef,
+};
 pub use error::{FlakeGeneratorError, Result};
 pub use generator::render_flake;
 pub use parser::LazyNixParser;

--- a/src/flake-generator/src/parser.rs
+++ b/src/flake-generator/src/parser.rs
@@ -115,7 +115,7 @@ devShell:
   allowUnfree: false
   package:
     stable:
-      - python312
+      - name: python312
 "#;
             fs::write("lazynix.yaml", config_content).unwrap();
 
@@ -123,7 +123,7 @@ devShell:
             let parser = LazyNixParser::new(PathBuf::from("."));
             let config = parser.read_config().unwrap();
 
-            assert_eq!(config.dev_shell.package.stable, vec!["python312"]);
+            assert_eq!(config.dev_shell.package.stable[0].name, "python312");
         });
     }
 
@@ -139,7 +139,7 @@ devShell:
   allowUnfree: true
   package:
     stable:
-      - rust
+      - name: rust
 "#;
             fs::write("configs/lazynix.yaml", config_content).unwrap();
 
@@ -148,7 +148,7 @@ devShell:
             let config = parser.read_config().unwrap();
 
             assert!(config.dev_shell.allow_unfree);
-            assert_eq!(config.dev_shell.package.stable, vec!["rust"]);
+            assert_eq!(config.dev_shell.package.stable[0].name, "rust");
         });
     }
 
@@ -178,14 +178,14 @@ devShell:
   allowUnfree: false
   package:
     stable:
-      - gcc
+      - name: gcc
 "#;
             fs::write("lazynix.yaml", config_content).unwrap();
 
             // Public function should still work
             let config = read_config().unwrap();
 
-            assert_eq!(config.dev_shell.package.stable, vec!["gcc"]);
+            assert_eq!(config.dev_shell.package.stable[0].name, "gcc");
         });
     }
 

--- a/src/nix-dispatcher/Cargo.toml
+++ b/src/nix-dispatcher/Cargo.toml
@@ -7,4 +7,6 @@ license = "MIT"
 repository = "https://github.com/shunsock/lazynix"
 
 [dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 thiserror = "1.0"

--- a/src/nix-dispatcher/src/lib.rs
+++ b/src/nix-dispatcher/src/lib.rs
@@ -10,4 +10,4 @@ pub use commands::{
     run_flake_update, run_nix_develop, run_nix_develop_command, run_nix_test, run_task_in_nix_env,
 };
 pub use error::{NixDispatcherError, Result};
-pub use version_resolver::{resolve_version, search_versions, ResolvedVersion};
+pub use version_resolver::{ResolvedVersion, resolve_version, search_versions};

--- a/src/nix-dispatcher/src/lib.rs
+++ b/src/nix-dispatcher/src/lib.rs
@@ -4,8 +4,10 @@
 
 pub mod commands;
 pub mod error;
+pub mod version_resolver;
 
 pub use commands::{
     run_flake_update, run_nix_develop, run_nix_develop_command, run_nix_test, run_task_in_nix_env,
 };
 pub use error::{NixDispatcherError, Result};
+pub use version_resolver::{resolve_version, ResolvedVersion};

--- a/src/nix-dispatcher/src/lib.rs
+++ b/src/nix-dispatcher/src/lib.rs
@@ -10,4 +10,4 @@ pub use commands::{
     run_flake_update, run_nix_develop, run_nix_develop_command, run_nix_test, run_task_in_nix_env,
 };
 pub use error::{NixDispatcherError, Result};
-pub use version_resolver::{resolve_version, ResolvedVersion};
+pub use version_resolver::{resolve_version, search_versions, ResolvedVersion};

--- a/src/nix-dispatcher/src/version_resolver.rs
+++ b/src/nix-dispatcher/src/version_resolver.rs
@@ -48,10 +48,7 @@ pub fn resolve_version(package_name: &str, version: &str) -> Result<ResolvedVers
         .arg(&spec)
         .output()
         .map_err(|e| {
-            NixDispatcherError::CommandExecution(format!(
-                "Failed to execute nix-versions: {}",
-                e
-            ))
+            NixDispatcherError::CommandExecution(format!("Failed to execute nix-versions: {}", e))
         })?;
 
     if !output.status.success() {
@@ -63,13 +60,9 @@ pub fn resolve_version(package_name: &str, version: &str) -> Result<ResolvedVers
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let results: Vec<NixVersionResult> =
-        serde_json::from_str(&stdout).map_err(|e| {
-            NixDispatcherError::CommandExecution(format!(
-                "Failed to parse nix-versions output: {}",
-                e
-            ))
-        })?;
+    let results: Vec<NixVersionResult> = serde_json::from_str(&stdout).map_err(|e| {
+        NixDispatcherError::CommandExecution(format!("Failed to parse nix-versions output: {}", e))
+    })?;
 
     let result = results.into_iter().next().ok_or_else(|| {
         NixDispatcherError::CommandExecution(format!(
@@ -97,9 +90,7 @@ pub fn search_versions(
     };
 
     let mut cmd = Command::new("nix");
-    cmd.arg("run")
-        .arg("github:vic/nix-versions")
-        .arg("--");
+    cmd.arg("run").arg("github:vic/nix-versions").arg("--");
 
     if json {
         cmd.arg("--json");

--- a/src/nix-dispatcher/src/version_resolver.rs
+++ b/src/nix-dispatcher/src/version_resolver.rs
@@ -1,0 +1,104 @@
+use std::process::Command;
+
+use serde::Deserialize;
+
+use crate::error::{NixDispatcherError, Result};
+
+#[derive(Debug, Deserialize)]
+pub struct NixVersionResult {
+    pub spec: String,
+    pub name: String,
+    pub version: String,
+    pub installable: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ResolvedVersion {
+    pub commit: String,
+    pub attr: String,
+}
+
+fn parse_installable(installable: &str) -> Result<ResolvedVersion> {
+    let rest = installable.strip_prefix("nixpkgs/").ok_or_else(|| {
+        NixDispatcherError::CommandExecution(format!(
+            "Unexpected installable format (missing nixpkgs/ prefix): {}",
+            installable
+        ))
+    })?;
+    let (commit, attr) = rest.split_once('#').ok_or_else(|| {
+        NixDispatcherError::CommandExecution(format!(
+            "Unexpected installable format (missing # separator): {}",
+            installable
+        ))
+    })?;
+    Ok(ResolvedVersion {
+        commit: commit.to_string(),
+        attr: attr.to_string(),
+    })
+}
+
+pub fn resolve_version(package_name: &str, version: &str) -> Result<ResolvedVersion> {
+    let spec = format!("{}@{}", package_name, version);
+    let output = Command::new("nix")
+        .arg("run")
+        .arg("github:vic/nix-versions")
+        .arg("--")
+        .arg("--json")
+        .arg("--one")
+        .arg(&spec)
+        .output()
+        .map_err(|e| {
+            NixDispatcherError::CommandExecution(format!(
+                "Failed to execute nix-versions: {}",
+                e
+            ))
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(NixDispatcherError::CommandExecution(format!(
+            "nix-versions failed for '{}': {}",
+            spec, stderr
+        )));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let results: Vec<NixVersionResult> =
+        serde_json::from_str(&stdout).map_err(|e| {
+            NixDispatcherError::CommandExecution(format!(
+                "Failed to parse nix-versions output: {}",
+                e
+            ))
+        })?;
+
+    let result = results.into_iter().next().ok_or_else(|| {
+        NixDispatcherError::CommandExecution(format!(
+            "No version found for '{}'. Use 'lnix search {}' to find available versions.",
+            spec, package_name
+        ))
+    })?;
+
+    parse_installable(&result.installable)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_installable_valid() {
+        let result = parse_installable("nixpkgs/5ed6275#go_1_21").unwrap();
+        assert_eq!(result.commit, "5ed6275");
+        assert_eq!(result.attr, "go_1_21");
+    }
+
+    #[test]
+    fn test_parse_installable_missing_prefix() {
+        assert!(parse_installable("invalid/5ed6275#go_1_21").is_err());
+    }
+
+    #[test]
+    fn test_parse_installable_missing_hash() {
+        assert!(parse_installable("nixpkgs/5ed6275").is_err());
+    }
+}

--- a/src/nix-dispatcher/src/version_resolver.rs
+++ b/src/nix-dispatcher/src/version_resolver.rs
@@ -81,6 +81,53 @@ pub fn resolve_version(package_name: &str, version: &str) -> Result<ResolvedVers
     parse_installable(&result.installable)
 }
 
+/// Search for package versions via nix-versions.
+///
+/// Calls `nix run github:vic/nix-versions -- [flags] '<spec>'`
+/// and returns the raw output.
+pub fn search_versions(
+    package_name: &str,
+    version_constraint: Option<&str>,
+    json: bool,
+    one: bool,
+) -> Result<String> {
+    let spec = match version_constraint {
+        Some(constraint) => format!("{}@{}", package_name, constraint),
+        None => package_name.to_string(),
+    };
+
+    let mut cmd = Command::new("nix");
+    cmd.arg("run")
+        .arg("github:vic/nix-versions")
+        .arg("--");
+
+    if json {
+        cmd.arg("--json");
+    } else {
+        cmd.arg("--text");
+    }
+
+    if one {
+        cmd.arg("--one");
+    }
+
+    cmd.arg(&spec);
+
+    let output = cmd.output().map_err(|e| {
+        NixDispatcherError::CommandExecution(format!("Failed to execute nix-versions: {}", e))
+    })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(NixDispatcherError::CommandExecution(format!(
+            "nix-versions search failed for '{}': {}",
+            spec, stderr
+        )));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/templates/lazynix.yaml.template
+++ b/src/templates/lazynix.yaml.template
@@ -2,8 +2,9 @@ devShell:
   allowUnfree: true
   package:
     stable:
-      - hello
+      - name: hello
     unstable: []
+    pinned: []
   shellHook:
     - "echo Welcome to LazyNix DevShell!"
 


### PR DESCRIPTION
## Summary

- **Breaking change**: `lazynix.yaml` のパッケージ形式を文字列リスト (`- python312`) からオブジェクト形式 (`- name: python312`) に変更
- `pinned` セクションを追加し、nix-versions 経由でバージョン固定パッケージをサポート
- `develop`/`test`/`run` コマンドで未解決の pinned パッケージを自動解決し、lazynix.yaml に書き戻す

## Test plan

- [x] 全ユニットテスト通過 (172 tests)
- [ ] pinned パッケージの resolvedCommit 自動解決の動作確認
- [ ] 生成された flake.nix が `nix develop` で正常に動作すること

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)