### PR TITLE
Add lnix search subcommand for version discovery

### DIFF
--- a/src/cli/src/cli_parser.rs
+++ b/src/cli/src/cli_parser.rs
@@ -85,4 +85,22 @@ pub enum Commands {
         #[arg(long)]
         arch: Option<String>,
     },
+
+    /// Search for available package versions via nix-versions
+    Search {
+        /// Package name to search for
+        package_name: String,
+
+        /// Version constraint (semver syntax, e.g., ">=1.20,<1.22")
+        #[arg(short, long)]
+        version: Option<String>,
+
+        /// Output results as JSON
+        #[arg(short, long)]
+        json: bool,
+
+        /// Show only the latest matching version
+        #[arg(short = '1', long)]
+        one: bool,
+    },
 }

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -12,7 +12,7 @@ use lazynix_settings_yaml::Settings;
 use lnix_flake_generator::{LazyNixParser, render_flake, validate_config};
 use lnix_nix_dispatcher::{
     resolve_version, run_flake_update, run_nix_develop, run_nix_develop_command, run_nix_test,
-    run_task_in_nix_env,
+    run_task_in_nix_env, search_versions,
 };
 use std::fs;
 use std::path::Path;
@@ -77,6 +77,12 @@ fn run() -> Result<()> {
                 std::process::exit(1);
             }
         }
+        Commands::Search {
+            package_name,
+            version,
+            json,
+            one,
+        } => cmd_search(&package_name, version.as_deref(), json, one)?,
     }
 
     Ok(())
@@ -349,4 +355,15 @@ fn resolve_pinned_packages(
     }
 
     Ok(resolved_any)
+}
+
+fn cmd_search(
+    package_name: &str,
+    version: Option<&str>,
+    json: bool,
+    one: bool,
+) -> Result<()> {
+    let output = search_versions(package_name, version, json, one)?;
+    print!("{}", output);
+    Ok(())
 }

--- a/src/nix-dispatcher/src/lib.rs
+++ b/src/nix-dispatcher/src/lib.rs
@@ -10,4 +10,4 @@ pub use commands::{
     run_flake_update, run_nix_develop, run_nix_develop_command, run_nix_test, run_task_in_nix_env,
 };
 pub use error::{NixDispatcherError, Result};
-pub use version_resolver::{resolve_version, ResolvedVersion};
+pub use version_resolver::{resolve_version, search_versions, ResolvedVersion};

--- a/src/nix-dispatcher/src/version_resolver.rs
+++ b/src/nix-dispatcher/src/version_resolver.rs
@@ -81,6 +81,53 @@ pub fn resolve_version(package_name: &str, version: &str) -> Result<ResolvedVers
     parse_installable(&result.installable)
 }
 
+/// Search for package versions via nix-versions.
+///
+/// Calls `nix run github:vic/nix-versions -- [flags] '<spec>'`
+/// and returns the raw output.
+pub fn search_versions(
+    package_name: &str,
+    version_constraint: Option<&str>,
+    json: bool,
+    one: bool,
+) -> Result<String> {
+    let spec = match version_constraint {
+        Some(constraint) => format!("{}@{}", package_name, constraint),
+        None => package_name.to_string(),
+    };
+
+    let mut cmd = Command::new("nix");
+    cmd.arg("run")
+        .arg("github:vic/nix-versions")
+        .arg("--");
+
+    if json {
+        cmd.arg("--json");
+    } else {
+        cmd.arg("--text");
+    }
+
+    if one {
+        cmd.arg("--one");
+    }
+
+    cmd.arg(&spec);
+
+    let output = cmd.output().map_err(|e| {
+        NixDispatcherError::CommandExecution(format!("Failed to execute nix-versions: {}", e))
+    })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(NixDispatcherError::CommandExecution(format!(
+            "nix-versions search failed for '{}': {}",
+            spec, stderr
+        )));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

- `lnix search` サブコマンドを追加
- nix-versions をラップして利用可能なパッケージバージョンを検索
- `--version` で制約付き検索、`--json` / `--one` フラグをサポート

## Usage

```bash
# 全バージョンを表示
lnix search go

# 制約付き検索
lnix search go --version ">=1.20,<1.22"

# JSON で最新の一致のみ
lnix search go --version ">=1.20" --json --one
```

## Test plan

- [x] 全ユニットテスト通過
- [ ] `lnix search go` の動作確認
- [ ] `lnix search go --version ">=1.20,<1.22" --json` の動作確認

Depends on #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)