### PR TITLE
Add per-crate READMEs and a workspace index

### DIFF
--- a/crates/README.md
+++ b/crates/README.md
@@ -1,0 +1,61 @@
+# LazyNix crates
+
+LazyNix is a Cargo workspace.
+
+The layout follows [astral-sh/uv](https://github.com/astral-sh/uv/tree/main/crates):
+one binary crate on top, with focused library crates underneath.
+
+This file is the index.
+
+Each crate has its own README with more detail.
+
+## Crates
+
+| Crate | Kind | Responsibility |
+|-------|------|----------------|
+| [`lnix`](./lnix) | binary | CLI entry point and command orchestration. |
+| [`lnix-core`](./lnix-core) | library | Domain value objects and the `lazynix.yaml` config AST. |
+| [`lnix-flake-generator`](./lnix-flake-generator) | library | Parse `lazynix.yaml` and render `flake.nix`. |
+| [`lnix-linter`](./lnix-linter) | library | Validate packages exist via `nix eval`. |
+| [`lnix-nix-dispatcher`](./lnix-nix-dispatcher) | library | Run `nix` commands as subprocesses. |
+
+## Dependency direction
+
+Dependencies flow in one direction.
+
+The binary depends on the libraries.
+
+The libraries depend on `lnix-core` (or nothing of ours).
+
+```
+                 lnix  (binary)
+        ┌──────────┼───────────┬───────────────────┐
+        v          v           v                   v
+ flake-generator  linter   nix-dispatcher          │
+        │          │                               │
+        └────┬─────┘                               │
+             v                                     │
+          lnix-core  <───────────────(no dep)──────┘
+```
+
+`lnix-core` is the foundation.
+
+It performs no I/O and depends only on `serde` and `thiserror`.
+
+`lnix-nix-dispatcher` is independent.
+
+It does not depend on any other LazyNix crate.
+
+## Why this shape
+
+Domain types live in one place (`lnix-core`).
+
+So validation rules are not duplicated across crates.
+
+Each library has a single responsibility.
+
+So a change to how Nix is invoked does not touch how YAML is parsed.
+
+The dependency graph has no cycles.
+
+So each crate can be understood, tested, and changed on its own.

--- a/crates/lnix-core/README.md
+++ b/crates/lnix-core/README.md
@@ -1,0 +1,86 @@
+# lnix-core
+
+Domain value objects and the configuration AST for LazyNix.
+
+## Overview
+
+This crate is the foundation of the workspace.
+
+It defines two things.
+
+First, value objects such as `PackageName` and `RegistryUrl`.
+
+Second, the `Config` AST that mirrors `lazynix.yaml`.
+
+It performs no I/O.
+
+It depends only on `serde` and `thiserror`.
+
+## Background
+
+Earlier, package-name validation was duplicated in three places.
+
+The flake generator, the linter, and the CLI each had their own check.
+
+The rules drifted apart over time.
+
+A `String` cannot tell you whether it was ever validated.
+
+So a missing check was easy to introduce and hard to notice.
+
+## Purpose
+
+Make illegal states unrepresentable.
+
+A value that exists in the program is already valid.
+
+Downstream code never re-checks it.
+
+## How it works
+
+Each value object wraps a `String`.
+
+It validates its invariant in `TryFrom<String>`.
+
+It is wired into `serde` with `#[serde(try_from = "String", into = "String")]`.
+
+So a successful deserialization *is* the proof of validity.
+
+An invalid name is rejected at YAML parse time, not later.
+
+Cross-field constraints that a single type cannot express live in `validate_config`.
+
+For example: a task must have at least one command.
+
+## Example
+
+A package name validates itself.
+
+```rust,ignore
+use lnix_core::PackageName;
+
+// Accepted: alphanumerics, '-', '_', and '.' for nested attributes.
+let name: PackageName = "python312Packages.pip".parse().unwrap();
+
+// Rejected: shell metacharacters cannot form a PackageName.
+assert!("pkg; rm -rf /".parse::<PackageName>().is_err());
+```
+
+Parsing a config rejects an invalid task name before any flake is generated.
+
+```rust,ignore
+use lnix_core::Config;
+
+let yaml = r#"
+devShell:
+  package:
+    stable:
+      - name: bash
+  task:
+    "invalid@name":
+      commands:
+        - echo hi
+"#;
+
+assert!(serde_yaml::from_str::<Config>(yaml).is_err());
+```

--- a/crates/lnix-flake-generator/README.md
+++ b/crates/lnix-flake-generator/README.md
@@ -1,0 +1,66 @@
+# lnix-flake-generator
+
+Parse `lazynix.yaml` and render `flake.nix`.
+
+## Overview
+
+This crate performs the core YAML-to-Nix transformation.
+
+It reads the config into the `lnix-core` AST.
+
+It renders that AST into a `flake.nix` string.
+
+## Background
+
+The generated flake has a fixed shape.
+
+It has stable, unstable, and pinned package inputs.
+
+It has a `shellHook` assembled from several fragments.
+
+Building that string in one large function was hard to follow.
+
+So the rendering is split by concern.
+
+## Purpose
+
+Turn a validated `Config` into a correct `flake.nix`.
+
+The output is deterministic.
+
+The same config always renders the same flake.
+
+## How it works
+
+The public surface is small.
+
+`LazyNixParser` reads and writes `lazynix.yaml`.
+
+`render_flake` turns a `Config` into a `String`.
+
+Rendering is split into focused modules under `generator/`:
+
+- `path` resolves `~/`, absolute, and relative paths at shell-hook runtime
+- `shell_hook` composes the ordered hook fragments
+- `test_runner` renders the `LAZYNIX_TEST_MODE` test block
+- `pinned` renders the per-package inputs and bindings
+- `build_inputs` groups the `buildInputs` list
+- `mod` orchestrates the final template
+
+There is no intermediate representation.
+
+The AST maps directly to the output string.
+
+## Example
+
+```rust,ignore
+use lnix_flake_generator::{LazyNixParser, render_flake};
+use std::path::PathBuf;
+
+// Read lazynix.yaml from a directory.
+let parser = LazyNixParser::new(PathBuf::from("."));
+let config = parser.read_config()?;
+
+// Render flake.nix. The override pins a different stable channel.
+let flake: String = render_flake(&config, Some("github:NixOS/nixpkgs/nixos-25.06"));
+```

--- a/crates/lnix-linter/README.md
+++ b/crates/lnix-linter/README.md
@@ -1,14 +1,71 @@
-# LazyNix Linter
+# lnix-linter
 
-Validates Nix packages before compilation using `nix eval`.
+Validate that declared packages exist, before you enter the shell.
 
-## Features (Planned)
+## Overview
 
-- Package existence validation
-- Architecture compatibility checking
-- User-friendly error messages
-- Parallel validation for performance
+This crate checks each package in `lazynix.yaml`.
 
-## Status
+It uses `nix eval` to confirm the package resolves.
 
-This module is currently under development as part of Epic Issue #92.
+It reports problems in a human-friendly form.
+
+## Background
+
+A typo in a package name is easy to make.
+
+Without a check, you find out only when `nix develop` fails.
+
+That failure is slow and the error is a wall of Nix output.
+
+The linter catches these problems early.
+
+It turns raw evaluation errors into actionable messages.
+
+## Purpose
+
+Fail fast, and fail clearly.
+
+Tell the user which package is wrong and why.
+
+Point them to where they can look it up.
+
+## How it works
+
+The flow is a short pipeline.
+
+- `nix_eval` runs `nix eval nixpkgs#<package>` for each package
+- `error_classifier` sorts a failure into a category
+- `validator` aggregates results across packages
+- `reporter` formats the outcome for the terminal
+
+Two design decisions matter.
+
+First, evaluation runs in parallel with [rayon](https://docs.rs/rayon/).
+
+This matters when many packages are declared.
+
+Second, errors are classified, not dumped.
+
+A failure becomes "package not found" or "unsupported architecture".
+
+The `--arch` flag checks a target other than the current system.
+
+For example, validate an `x86_64-linux` config from an `aarch64-darwin` machine.
+
+Package names arrive as `lnix_core::PackageName`.
+
+So shell-injection safety is a type guarantee, not a runtime check.
+
+## Example
+
+```rust,ignore
+use lnix_core::PackageName;
+use lnix_linter::{validate_packages, format_validation_result};
+
+let packages: Vec<PackageName> =
+    vec!["vim".parse().unwrap(), "git".parse().unwrap()];
+
+let result = validate_packages(&packages, None);
+print!("{}", format_validation_result(&result));
+```

--- a/crates/lnix-nix-dispatcher/README.md
+++ b/crates/lnix-nix-dispatcher/README.md
@@ -1,39 +1,77 @@
 # lnix-nix-dispatcher
 
-Nix command dispatcher for LazyNix.
+Run `nix` commands as subprocesses.
 
 ## Overview
 
-This crate provides a clean interface for executing Nix commands within the LazyNix environment. It handles command execution, error handling, and provides a consistent API for Nix operations.
+This crate is the boundary between LazyNix and the `nix` CLI.
 
-## Features
+It launches `nix` processes.
 
-- Execute `nix develop` shells
-- Run commands within Nix development environments
-- Update flake.lock files
-- Run tests in Nix environments
-- Execute tasks with command interpolation
+It handles their exit codes and reports errors.
 
-## Usage
+## Background
 
-```rust
-use lnix_nix_dispatcher::{run_nix_develop, run_nix_develop_command};
+LazyNix drives Nix, it does not reimplement it.
 
-// Enter nix develop shell
-run_nix_develop()?;
+Spawning subprocesses and threading exit codes is repetitive.
 
-// Run a command in nix develop environment
-let exit_code = run_nix_develop_command(vec!["cargo".to_string(), "build".to_string()])?;
-```
+Centralizing it here keeps the rest of the codebase clean.
+
+The CLI calls one function instead of building a `Command`.
+
+## Purpose
+
+Provide a small, consistent API for Nix operations.
+
+Abstract away the details of process spawning.
+
+Leave the interpretation of output to the caller.
+
+## How it works
+
+Each function builds the right `nix` invocation.
+
+It launches it as a subprocess.
+
+It returns either an exit code or an error.
+
+This crate does not parse Nix output.
+
+It only distinguishes success from failure.
+
+A non-zero exit code from `nix` is not a Rust error.
+
+It is returned as an `i32` so the caller can decide what to do.
+
+Typically the caller forwards it as the `lnix` exit code.
 
 ## API
 
-- `run_nix_develop()` - Enter an interactive nix develop shell
-- `run_flake_update()` - Update flake.lock file
-- `run_nix_develop_command(cmd_args)` - Execute a command in nix develop
-- `run_nix_test()` - Run tests in nix environment with LAZYNIX_TEST_MODE=1
-- `run_task_in_nix_env(commands)` - Execute multiple commands sequentially
+| Function | Behavior |
+|----------|----------|
+| `run_nix_develop()` | Enter an interactive `nix develop` shell. |
+| `run_nix_develop_command(args)` | Run one command inside `nix develop`. |
+| `run_flake_update()` | Run `nix flake update`. |
+| `run_nix_test()` | Run tests with `LAZYNIX_TEST_MODE=1`. |
+| `run_task_in_nix_env(commands)` | Run several commands sequentially. |
+| `resolve_version(name, version)` | Resolve a pinned version via nix-versions. |
+| `search_versions(...)` | Search available versions via nix-versions. |
 
-## Error Handling
+## Example
 
-All functions return `Result<T, NixDispatcherError>` for consistent error handling.
+```rust,ignore
+use lnix_nix_dispatcher::{run_nix_develop, run_nix_develop_command};
+
+// Enter an interactive dev shell.
+run_nix_develop()?;
+
+// Or run a single command inside it.
+let exit_code = run_nix_develop_command(vec!["cargo".to_string(), "build".to_string()])?;
+```
+
+## Error handling
+
+All functions return `Result<T, NixDispatcherError>`.
+
+A missing `nix` binary and a failed spawn are the error cases.

--- a/crates/lnix/README.md
+++ b/crates/lnix/README.md
@@ -1,0 +1,84 @@
+# lnix
+
+The LazyNix command-line tool.
+
+This is the only binary crate in the workspace.
+
+## Overview
+
+`lnix` is a YAML-to-Nix transpiler for lazy engineers.
+
+You describe a dev environment in `lazynix.yaml`.
+
+`lnix` generates a `flake.nix` and drives `nix` for you.
+
+## Background
+
+A Nix `flake.nix` is powerful but verbose.
+
+Writing one by hand is a barrier for many developers.
+
+LazyNix trades a small, declarative YAML file for that boilerplate.
+
+The generated `flake.nix` is disposable.
+
+You edit the YAML, not the flake.
+
+## Purpose
+
+Be a thin orchestration layer.
+
+This crate holds no business logic of its own.
+
+It parses arguments and delegates to the library crates.
+
+## How it works
+
+`main.rs` parses arguments with [clap](https://docs.rs/clap/) and dispatches.
+
+Each subcommand lives in its own module under `commands/`.
+
+The commands that generate a flake share one pipeline.
+
+`commands/pipeline.rs` holds that shared prefix:
+
+1. read and validate the config (`lnix-core`, `lnix-flake-generator`)
+2. resolve pinned package versions (`lnix-nix-dispatcher`)
+3. render and write `flake.nix` (`lnix-flake-generator`)
+
+A command then adds its own tail.
+
+`develop` enters the shell, `test` runs tests, `run` runs a command.
+
+Errors follow a railway pattern.
+
+Each step returns a `Result`, and errors bubble up to `main`.
+
+## Subcommands
+
+| Command | What it does |
+|---------|--------------|
+| `init` | Scaffold `lazynix.yaml` and `flake.nix` from templates. |
+| `develop` | Generate `flake.nix` and enter `nix develop`. |
+| `run` | Run a command inside the dev environment. |
+| `test` | Run the test commands declared in `lazynix.yaml`. |
+| `task` | Run a named task from `lazynix.yaml`. |
+| `update` | Update `flake.lock`. |
+| `lint` | Check that declared packages exist via `nix eval`. |
+| `search` | Find available package versions via nix-versions. |
+
+## Example
+
+```bash
+# Scaffold a project.
+lnix init
+
+# Edit lazynix.yaml, then enter the dev shell.
+lnix develop
+
+# Run a one-off command in the environment.
+lnix run -- cargo build
+
+# Check that every declared package resolves.
+lnix lint
+```


### PR DESCRIPTION
## Background

refactor.md は「crate ごとに README を作る」「概要・背景・目的・手法・処理の事例を紹介する」「1文を短く、改行を多めに」と求めています。

リファクタリング前の状態には2つの問題がありました。

第一に、README が一部の crate にしかありませんでした。

`lnix`・`lnix-core`・`lnix-flake-generator` には README がありませんでした。

第二に、既存の README が古くなっていました。

`lnix-linter` の README は "Features (Planned)" / "under development as part of Epic Issue #92" のままでした。

実際にはリンターは完成して出荷されています。

これは PR #20〜#22 の構成・型・分割リファクタリングを締めくくる、ドキュメント整備の最終PRです。

## Approach

uv の crates ドキュメント慣習に倣いました。

ワークスペース直下に索引（`crates/README.md`）を置きます。

各 crate には統一構成の README を置きます。

### 構成の統一

各 README は同じ見出しで揃えました。

| セクション | 内容 |
|-----------|------|
| Overview | この crate が何をするか |
| Background | なぜ必要か / どんな問題を解くか |
| Purpose | 設計上の狙い |
| How it works | 内部構造・主要モジュール |
| Example | 最小の使用例 |

### 文体

refactor.md の指示に従い、1文を短くしました。

改行を多めに入れ、流し読みできるようにしました。

## What Changed

### 新規 README

- `crates/README.md` — 索引。crate 一覧テーブルと依存方向のダイアグラム
- `crates/lnix/README.md` — バイナリ。サブコマンド表と共通パイプラインの説明
- `crates/lnix-core/README.md` — バリューオブジェクトと parse-don't-validate の解説
- `crates/lnix-flake-generator/README.md` — generator/ サブモジュールの責務

### 既存 README の刷新

- `crates/lnix-linter/README.md` — "Planned" の記述を実装済みの内容へ全面改稿。並列評価・エラー分類・型によるインジェクション防止を記載
- `crates/lnix-nix-dispatcher/README.md` — 統一構成へ整理し、`resolve_version` / `search_versions` を API 表に追加

## Tradeoffs and Limitations

- **Rust 例は ```rust,ignore**: `lnix-linter` は `lib.rs` で `#![doc = include_str!("../README.md")]` しているため、コードブロックは doctest になり得ます。README の例は説明用で完全なコンパイル文脈を持たないため、`ignore` を付けて doctest 化を避けました（`cargo test -p lnix-linter --doc` で ignored を確認済み）
- **README は英語**: OSS の慣例と既存ドキュメントに合わせました。日本語の詳細解説は `document/jp/` に別途あります
- **索引は手動メンテ**: crate 追加時に `crates/README.md` の表と図を更新する必要があります。crate 追加は稀なため自動生成は導入しませんでした

## Testing

- `cargo test -p lnix-linter --doc` — README を含む doc テストがパス（Rust 例は ignored）
- `cargo build -p lnix-linter` — `include_str!` 経由の README 取り込みがビルドを壊さないことを確認
- README はコードを変更しないため、CI の cargo ジョブ（paths フィルタ）はトリガーされません

## Review Guide

1. まず `crates/README.md` を読んでください — ワークスペース全体の地図です
2. 次に各 crate の README を上から（`lnix` → `lnix-core` → ...）読むと、依存の流れに沿って理解できます
3. 文体（1文の短さ・改行）が refactor.md の指示に沿っているか確認してください

🤖 Generated with [Claude Code](https://claude.com/claude-code)
