### PR TITLE
ci: workflow-level paths filter を撤去して全 PR で cargo check を報告する

### DIFF
--- a/.github/workflows/pass_cargo_commands.yml
+++ b/.github/workflows/pass_cargo_commands.yml
@@ -1,16 +1,13 @@
 name: Cargo Commands CI
 
+# workflow-level の paths filter は使わない。rust 無関係な PR (github-actions 更新等) で
+# workflow 自体が発火せず、required status check が「待ち」で詰まるのを避けるため。
+# 変更範囲の判定は detect-changes ジョブ (dorny/paths-filter) が内部で行い、
+# rust に無関係な PR では cargo ジョブが skip される (skip された required check は passing 扱い)。
 on:
   pull_request:
     branches:
       - main
-    paths:
-      - crates/*/src/**/*.rs
-      - crates/*/tests/**/*.rs
-      - crates/*/Cargo.toml
-      - crates/*/templates/**
-      - Cargo.toml
-      - Cargo.lock
 
 permissions:
   contents: read


### PR DESCRIPTION
## 概要

`pass_cargo_commands.yml` の workflow-level paths filter を撤去し、全 PR で `cargo fmt + clippy` / `cargo test` の check を必ず報告するようにする。dependabot auto-merge の required status check 化に向けた前提整備。

## 背景

lazynix を rust-cli auto-merge グループ（shunsock/github_central）へ載せる計画で、cargo チェックを required にしたい。ところが現状は workflow-level の `paths:` を持つため、rust 無関係な PR（github-actions 更新等）では workflow が発火せず check が報告されない → required にすると詰まる。

lazynix は既に `detect-changes` ジョブ（`dorny/paths-filter`）で変更範囲を内部判定し、cargo ジョブを `if: any-crate == 'true'` で条件実行している。よって **workflow-level の `paths:` は冗長**で、撤去しても挙動は変わらない。

## 変更箇所

- `.github/workflows/pass_cargo_commands.yml`: `on.pull_request.paths` を撤去

## 妥協と制限

- 非 rust PR でも `detect-changes` ジョブは起動する（paths-filter のみ、軽微）。
- （既存仕様）per-crate の clippy/test は crate 単位の変更検出で step gating される。root `Cargo.lock` のみの変更では一部 step が skip される。auto-merge の検証強度に関わるが本 PR のスコープ外。

## 検証方法

- `actionlint` / `ghalint` / `zizmor` pass
- 本 PR は workflow ファイルのみ変更（非 cargo path）のため、`detect-changes` が any-crate=false と判定し `cargo fmt + clippy` / `cargo test` が **skip される**挙動（=required でも詰まらない）を CI 上で確認できる

## 確認事項

- ⚠️ この後 github_central 側で lazynix を PR 必須化し、required_status_checks に cargo チェック + lint5 を設定する（nix チェックは除外）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)