### PR TITLE
fix(nix): crane src フィルタのテンプレートパスを lnix-infra に追従

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,7 @@
           src = ./.;
           filter = path: type:
             (craneLib.filterCargoSources path type)
-            || (builtins.match ".*crates/lnix/templates/.*" path != null)
+            || (builtins.match ".*crates/lnix-infra/templates/.*" path != null)
             || (builtins.match ".*/README\.md$" path != null);
         };
 
@@ -104,7 +104,7 @@
           src = ./.;
           filter = path: type:
             (craneLib.filterCargoSources path type)
-            || (builtins.match ".*crates/lnix/templates/.*" path != null)
+            || (builtins.match ".*crates/lnix-infra/templates/.*" path != null)
             || (builtins.match ".*/README\.md$" path != null);
         };
 


### PR DESCRIPTION
## 概要

Nix ビルド (`nix build .#default`) が `include_str!` のコンパイルエラーで失敗する問題を修正する。`flake.nix` の crane ソースフィルタが参照するテンプレートのパスを、クレート分割後の実配置 `crates/lnix-infra/templates/` に追従させる。

## 背景

`crates/lnix-infra/src/persistence/scaffolder.rs` は、スキャフォールド用の雛形をバイナリに埋め込むために `include_str!` でテンプレートを参照している。

```rust
const YAML_TEMPLATE: &str = include_str!("../../templates/lazynix.yaml.template");
const FLAKE_TEMPLATE: &str = include_str!("../../templates/flake.nix.init.template");
```

一方、Nix ビルドは crane の `filterCargoSources` でソースを絞り込む。このフィルタは `.rs` / `Cargo.toml` / `Cargo.lock` 以外を除外するため、`.template` ファイルを取り込むには明示的な追加フィルタが必要になる。`flake.nix` にはそのための分岐が既にあったが、参照パスがクレート分割前の旧構成 `crates/lnix/templates/` のままだった。

## 課題

テンプレートの実体は `crates/lnix-infra/templates/` に存在するのに、フィルタは `crates/lnix/templates/` を探すため、`.template` がビルドサンドボックスに入らない。結果として `include_str!` が対象ファイルを読めず、コンパイルが失敗する。

```
error: couldn't read `crates/lnix-infra/src/persistence/../../templates/lazynix.yaml.template`:
       No such file or directory (os error 2)
error: could not compile `lnix-infra` (lib) due to 2 previous errors
```

ローカルの `cargo build` はソースツリー全体を見えるため再現せず、Nix ビルド (crane のサンドボックス) でのみ顕在化する。

## 目標

- 必須: `nix build .#default` が成功すること
- 必須: `releasePackages` / `eachDefaultSystem` の両ビルド経路で同じ修正を適用すること
- 範囲外: crane フィルタの一般化やテンプレート配置の再設計

## 採用手法

| 選択肢 | 内容 | 評価 |
|---|---|---|
| フィルタのパスを実配置に修正 (採用) | `crates/lnix/templates/` → `crates/lnix-infra/templates/` | 変更最小・意図が明確。クレート構成と 1:1 対応 |
| パスを汎用化 (`.*/templates/.*`) | ディレクトリ名に依存しない | 将来のリネームに強いが、意図しないファイルを取り込むリスク。今回の bug の範囲を超える |

今回は「クレート分割にフィルタが追従していない」という単一原因なので、実配置に合わせる最小修正を採用した。

## 変更箇所

- `flake.nix`: crane src フィルタのテンプレート照合パスを `crates/lnix-infra/templates/` に更新 (リリース用・`eachDefaultSystem` 用の 2 箇所)

## 妥協と制限

- フィルタはディレクトリ名をハードコードしているため、再度クレートを移設するとまた追従が必要になる。今回は範囲を絞り汎用化はしていない。

## 検証方法

- `nix build .#default --no-link` がローカル (aarch64-darwin) で成功することを確認
- 修正前は `include_str!` の 2 ファイルで `No such file or directory` により失敗することを確認

## 確認事項

- ⚠️ フィルタを汎用パターン (`.*/templates/.*`) にするかは設計判断。将来の再発防止と過剰マッチのトレードオフ。今回は最小修正を選択したが、方針の希望があれば差し替え可能。

## 参考文献

- 影響先: shunsock/dotfiles の nix-darwin 構成 (最新 lazynix を follows でビルドする際に本 bug を踏む)

🤖 Generated with [Claude Code](https://claude.com/claude-code)