### PR TITLE
feat: add lnix generate subcommand for shell-free flake.nix generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,16 @@ LazyNix will automatically:
 3. 🔒 Update `flake.lock` with pinned dependencies (with `--update`)
 4. 🚀 Enter the Nix development shell with all specified packages
 
+### 📝 Generate `flake.nix` Only
+
+Regenerate `flake.nix` from `lazynix.yaml` without entering a shell or running any commands:
+
+```bash
+lnix generate
+```
+
+Handy for CI validation, applying edits to `lazynix.yaml`, or preparing to migrate to Pure Nix. When no pinned packages are configured, this runs fully offline without invoking Nix.
+
 ## Configuration
 
 ### Custom Config Directory
@@ -218,8 +228,9 @@ override-stable-package: "github:myorg/nixpkgs/custom-branch"
 
 When you need advanced Nix features, migration is seamless. LazyNix generates a standard `flake.nix`, so:
 
-1. 🗑️ Delete `lazynix.yaml`
-2. ✏️ Continue editing `flake.nix` directly
+1. ⚙️ Run `lnix generate` to produce the latest `flake.nix` from `lazynix.yaml`
+2. 🗑️ Delete `lazynix.yaml`
+3. ✏️ Continue editing `flake.nix` directly
 
 That's all! Your development environment keeps working without any changes.
 

--- a/crates/lnix-app/src/lib.rs
+++ b/crates/lnix-app/src/lib.rs
@@ -21,4 +21,4 @@ mod usecase;
 
 pub use deps::Deps;
 pub use error::ApplicationError;
-pub use usecase::{develop, init, lint, run, search, task, test, update};
+pub use usecase::{develop, generate, init, lint, run, search, task, test, update};

--- a/crates/lnix-app/src/usecase/generate.rs
+++ b/crates/lnix-app/src/usecase/generate.rs
@@ -1,0 +1,137 @@
+//! `lnix generate` — render `flake.nix` from `lazynix.yaml` and exit.
+
+use crate::deps::Deps;
+use crate::error::ApplicationError;
+use crate::pipeline;
+
+/// Renders `flake.nix` from the current config and returns the exit code.
+///
+/// Unlike `develop`, `generate` never spawns any Nix subprocess: no
+/// shell entry, no ad-hoc command, and no `flake.lock` update. This
+/// keeps the command usable in environments (CI dry runs, editor
+/// integrations) where evaluating Nix is undesirable, and preserves
+/// the property that a config without `pinned` entries requires zero
+/// Nix invocations.
+pub fn generate(d: &Deps) -> Result<i32, ApplicationError> {
+    let loaded = pipeline::load_config(d)?;
+    pipeline::write_flake(d, &loaded)?;
+    Ok(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mocks::*;
+    use lnix_domain::ConfigError;
+
+    #[test]
+    fn writes_flake_with_configured_package_and_returns_zero() {
+        // Arrange
+        let m = Mocks::with_config(config_from_yaml(
+            "devShell:\n  package:\n    stable:\n      - name: bash\n",
+        ));
+
+        // Act
+        let code = generate(&m.deps()).unwrap();
+
+        // Assert
+        assert_eq!(code, 0);
+        let written = m.writer.written().expect("flake.nix should be written");
+        assert!(written.contains("bash"));
+    }
+
+    #[test]
+    fn does_not_enter_the_dev_shell() {
+        // Arrange
+        let m = Mocks::with_config(config_from_yaml(
+            "devShell:\n  package:\n    stable:\n      - name: bash\n",
+        ));
+
+        // Act
+        generate(&m.deps()).unwrap();
+
+        // Assert
+        assert_eq!(m.nix.develop_calls(), 0);
+    }
+
+    #[test]
+    fn does_not_execute_any_ad_hoc_command() {
+        // Arrange
+        let m = Mocks::with_config(config_from_yaml(
+            "devShell:\n  package:\n    stable:\n      - name: bash\n",
+        ));
+
+        // Act
+        generate(&m.deps()).unwrap();
+
+        // Assert
+        assert!(m.nix.develop_command_args().is_none());
+    }
+
+    #[test]
+    fn does_not_update_the_flake_lock() {
+        // Arrange
+        let m = Mocks::with_config(config_from_yaml(
+            "devShell:\n  package:\n    stable:\n      - name: bash\n",
+        ));
+
+        // Act
+        generate(&m.deps()).unwrap();
+
+        // Assert
+        assert_eq!(m.nix.flake_update_calls(), 0);
+    }
+
+    #[test]
+    fn missing_config_short_circuits_before_any_side_effect() {
+        // Arrange
+        let m = Mocks::with_missing_config();
+
+        // Act
+        let result = generate(&m.deps());
+
+        // Assert
+        assert!(matches!(
+            result,
+            Err(ApplicationError::Config(ConfigError::NotFound(_)))
+        ));
+        assert!(m.writer.written().is_none());
+    }
+
+    #[test]
+    fn resolves_pinned_packages_and_persists_them() {
+        // Arrange
+        let m = Mocks::with_config(config_from_yaml(
+            "devShell:\n  package:\n    stable:\n      - name: bash\n    pinned:\n      - name: go\n        version: \"1.21.13\"\n",
+        ));
+
+        // Act
+        generate(&m.deps()).unwrap();
+
+        // Assert
+        let persisted = m.repo.persisted_config().unwrap();
+        let pinned = &persisted.dev_shell.package.pinned[0];
+        assert_eq!(pinned.resolved_commit.as_deref(), Some("e607cb5"));
+        assert_eq!(pinned.resolved_attr.as_deref(), Some("go_1_21"));
+        assert!(m.writer.written().unwrap().contains("go_1_21"));
+    }
+
+    #[test]
+    fn missing_dotenv_fails_before_writing_flake() {
+        // Arrange
+        let m = Mocks::with_config(config_from_yaml(
+            "devShell:\n  package:\n    stable:\n      - name: bash\n  env:\n    dotenv:\n      - .env\n",
+        ))
+        .with_missing_env_files();
+
+        // Act
+        let result = generate(&m.deps());
+
+        // Assert
+        assert!(matches!(
+            result,
+            Err(ApplicationError::Config(ConfigError::DotenvFileNotFound(_)))
+        ));
+        assert!(m.writer.written().is_none());
+    }
+}

--- a/crates/lnix-app/src/usecase/mod.rs
+++ b/crates/lnix-app/src/usecase/mod.rs
@@ -5,6 +5,7 @@
 //! rail, a categorized failure otherwise.
 
 mod develop;
+mod generate;
 mod init;
 mod lint;
 mod run;
@@ -14,6 +15,7 @@ mod test;
 mod update;
 
 pub use develop::develop;
+pub use generate::generate;
 pub use init::init;
 pub use lint::lint;
 pub use run::run;

--- a/crates/lnix-infra/templates/lazynix-settings.yaml.template
+++ b/crates/lnix-infra/templates/lazynix-settings.yaml.template
@@ -43,7 +43,7 @@
 #
 # - This file is OPTIONAL. LazyNix works without it using sensible defaults.
 # - Invalid URLs will produce validation errors when running lnix commands.
-# - Changes take effect when you run: lnix develop, lnix build, or lnix run
+# - Changes take effect when you run: lnix develop, lnix generate, or lnix run
 # - The generated flake.nix will reflect your override setting.
 # - Add lazynix-settings.yaml to .gitignore if settings are user-specific.
 #

--- a/crates/lnix/src/cli_parser.rs
+++ b/crates/lnix/src/cli_parser.rs
@@ -36,6 +36,9 @@ pub enum Commands {
     /// Update flake.lock without entering development shell
     Update,
 
+    /// Generate flake.nix from lazynix.yaml without entering the shell
+    Generate,
+
     /// Generate flake.nix from lazynix.yaml and enter nix develop shell
     Develop {
         /// Update flake.lock before entering the shell

--- a/crates/lnix/src/main.rs
+++ b/crates/lnix/src/main.rs
@@ -32,6 +32,7 @@ fn route(command: Commands, d: &Deps) -> Result<i32, ApplicationError> {
     match command {
         Commands::Init { force } => lnix_app::init(d, force),
         Commands::Update => lnix_app::update(d),
+        Commands::Generate => lnix_app::generate(d),
         Commands::Develop { update } => lnix_app::develop(d, update),
         Commands::Test { update } => lnix_app::test(d, update),
         Commands::Run {

--- a/crates/lnix/tests/generate_command_test.rs
+++ b/crates/lnix/tests/generate_command_test.rs
@@ -1,0 +1,55 @@
+use predicates::prelude::*;
+
+mod common;
+use common::*;
+
+#[test]
+fn test_generate_help_message() {
+    lnix_cmd()
+        .arg("generate")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Generate flake.nix"));
+}
+
+#[test]
+fn test_generate_missing_config_file() {
+    let temp_dir = setup_test_dir();
+
+    lnix_cmd()
+        .arg("-C")
+        .arg(temp_dir.path())
+        .arg("generate")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("lazynix.yaml"));
+}
+
+#[test]
+fn test_generate_invalid_yaml_syntax() {
+    let temp_dir = setup_test_dir_with_config(&invalid_yaml_config());
+
+    lnix_cmd()
+        .arg("-C")
+        .arg(temp_dir.path())
+        .arg("generate")
+        .assert()
+        .failure();
+}
+
+#[test]
+fn test_generate_writes_flake_nix_without_nix_subprocess() {
+    let temp_dir = setup_test_dir_with_config(&config_with_packages(&["bash"], &[]));
+
+    lnix_cmd()
+        .env("PATH", "")
+        .arg("-C")
+        .arg(temp_dir.path())
+        .arg("generate")
+        .timeout(std::time::Duration::from_secs(5))
+        .assert()
+        .success();
+
+    assert!(temp_dir.path().join("flake.nix").exists());
+}

--- a/crates/lnix/tests/help_and_version_test.rs
+++ b/crates/lnix/tests/help_and_version_test.rs
@@ -15,6 +15,7 @@ fn test_help_message() {
         .stdout(predicate::str::contains("develop"))
         .stdout(predicate::str::contains("test"))
         .stdout(predicate::str::contains("update"))
+        .stdout(predicate::str::contains("generate"))
         .stdout(predicate::str::contains("run"))
         .stdout(predicate::str::contains("task"))
         .stdout(predicate::str::contains("lint"));
@@ -73,6 +74,7 @@ fn test_help_shows_all_commands() {
             .and(predicate::str::contains("develop"))
             .and(predicate::str::contains("test"))
             .and(predicate::str::contains("update"))
+            .and(predicate::str::contains("generate"))
             .and(predicate::str::contains("run"))
             .and(predicate::str::contains("task"))
             .and(predicate::str::contains("lint")),


### PR DESCRIPTION
## 概要

`lazynix.yaml` から `flake.nix` を生成するだけのサブコマンド `lnix generate` を追加する。シェルに入らず、コマンドを実行せず、`flake.lock` にも触れない。

Closes #61

## 背景

LazyNix の中核は「`lazynix.yaml` から `flake.nix` を生成する」ことなのに、生成だけを行う手段が CLI に存在しなかった。生成物を得るには対話シェルに入る (`lnix develop`) か、`lnix run -- true` のような無意味なコマンドを実行するしかなかった。この不在は #60 (examples の生成物検証) の設計中に顕在化し、設定テンプレートには当初この種のコマンドが想定されていた形跡である存在しない `lnix build` への言及が残っていた。

## 課題

- README が案内する Pure Nix への移行手順が実行できない。手順の前提となる「最新の `lazynix.yaml` を反映した `flake.nix` を用意する」素直な手段がない
- #57 / #60 の CI 検証が `lnix run -- true` や `lnix lint` (ネットワーク I/O を伴い遅い) による回避策を強いられる
- `crates/lnix-infra/templates/lazynix-settings.yaml.template` が存在しない `lnix build` に言及している

## 目標

### 必須項目

- シェルに入らず、コマンドを実行せず、`lazynix.yaml` から `flake.nix` を生成できる
- pinned を含まない設定に対し、Nix のサブプロセスを一切起動しない (オフライン・高速)
- `develop` と生成ロジックを共有し、コードが重複しない
- 存在しない `lnix build` への言及を解消する

### 範囲外

- #57 / #60 の CI 検証の書き換え (両 issue は未着手のため、書き換え対象の CI が存在しない)
- `lnix task` が flake.nix を再生成しない問題 (issue #61 の補足で別途検討とされている)

## 採用手法

生成パイプラインは既に `pipeline` モジュール (`crates/lnix-app/src/pipeline.rs`) へ切り出されており、`develop` は実質「pipeline + シェル起動」でしかない。`generate` はその前半 (`load_config` + `write_flake`) を呼ぶだけの薄いユースケースとして実装した。

```mermaid
flowchart LR
  Y[lazynix.yaml] --> P[pipeline::load_config]
  P --> W[pipeline::write_flake]
  W --> F[flake.nix]
  W -->|develop のみ| S[nix develop シェル起動]
```

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: `lnix generate` を追加 (採用) | 意味が明確。既存 pipeline の再利用のみで実装が小さい | サブコマンドが 1 つ増える |
| B: `lnix build` という名前で追加 | テンプレートの既存記述と一致 | Nix の `nix build` (派生物のビルド) と語彙が衝突し誤解を招く |
| C: `lnix develop --no-shell` フラグ | サブコマンドが増えない | 「develop するがシェルに入らない」は自己矛盾した命名 |
| D: `lnix run -- true` を公式回避策として案内 | 実装ゼロ | 無意味なコマンド実行を強い、Nix シェル起動の分だけ遅い |

### 採用理由

LazyNix は Nix の薄いラッパーであり、Nix ユーザーの語感を裏切るべきではない。`generate` は生成物 (`flake.nix`) を作る操作として素直である。

issue で実装時判断とされていた `--update` フラグは**持たせない**ことにした。`flake.lock` 更新は既に `lnix update` が担っており機能が重複すること、「pinned を含まない設定なら Nix サブプロセスを一切起動しない」性質が CI から使う検証プリミティブとしての核心であること、が理由である。フラグの非対称は `generate` だけが Nix を起動しないという挙動の非対称を正直に映している。

## 変更箇所

- `crates/lnix-app/src/usecase/generate.rs`:generate ユースケースを新規追加 (pipeline の前半のみ呼ぶ)
- `crates/lnix-app/src/usecase/mod.rs`, `crates/lnix-app/src/lib.rs`:generate の公開
- `crates/lnix/src/cli_parser.rs`:`Generate` サブコマンドを追加 (フラグなし)
- `crates/lnix/src/main.rs`:route に `Commands::Generate` の配線を追加
- `crates/lnix/tests/generate_command_test.rs`:統合テストを新規追加
- `crates/lnix/tests/help_and_version_test.rs`:help 一覧のアサーションに generate を追加
- `crates/lnix-infra/templates/lazynix-settings.yaml.template`:存在しない `lnix build` を `lnix generate` に修正
- `README.md`:`### 📝 Generate flake.nix Only` セクションを追加し、Pure Nix 移行手順を 3 ステップ (generate → delete → edit) に更新

## 妥協と制限

- **`--update` の非対称**:`develop` / `run` / `test` は `--update` を持つが `generate` は持たない。機能の重複回避とオフライン性の保持を、フラグ体系の対称性より優先した
- **pinned 解決時は外部プロセスを呼ぶ**:未解決の pinned エントリを含む設定では版解決のためサブプロセスを起動する (既存 pipeline の挙動そのまま)

## 検証方法

- 単体テスト 7 件 (`usecase/generate.rs`): flake 書き出し / シェル非侵入 (`develop_calls == 0`) / コマンド非実行 / lock 非更新 / 設定なしの副作用ゼロ失敗 / pinned 解決と書き戻し / dotenv 欠落の事前失敗
- 統合テスト 4 件: 生成テストは `.env("PATH", "")` で Nix バイナリを解決不能にした状態で成功を検証し、「Nix サブプロセス非起動」を実証。既存コマンドと違い `#[ignore]` なしで CI 実行可能
- 実バイナリ QA 9 ケース: 冪等性 (再実行でバイト一致)、存在しない設定ディレクトリ、空パッケージリスト、pinned + Nix 不在時の graceful failure、`lnix run` の生成物とのバイト一致
- カバレッジ: `generate.rs` line 100% / region 97.5% (cargo llvm-cov)。認知的複雑度は全変更ファイルでベースライン以下
- workspace 全テスト 17 スイート通過、clippy 警告なし、rustfmt 差分なし

## 確認事項

- ⚠️ `--update` フラグを持たせない判断 (issue #61 では実装時判断とされていた点)。対称性を優先するなら追加は容易
- README の新セクションの配置 (Quick Start 直下)

## 参考文献

- [Issue #61: feat: lnix generate — flake.nix を生成するだけのサブコマンドが無い](https://github.com/shunsock/lazynix/issues/61)
- [Issue #60: examples のコミット済み生成物 (flake.nix) が陳腐化する構造になっている](https://github.com/shunsock/lazynix/issues/60)
- [Issue #57: docs: README / document / examples / init テンプレートを v0.3.0 に向けて全面改訂する](https://github.com/shunsock/lazynix/issues/57)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
