### PR TITLE
fix(lint): pinned パッケージを検証対象に含めバージョン解決も検証する

### DIFF
--- a/crates/lnix-app/src/mocks.rs
+++ b/crates/lnix-app/src/mocks.rs
@@ -210,14 +210,29 @@ impl NixEvaluator for StubEvaluator {
     }
 }
 
-pub(crate) struct StubResolver;
+#[derive(Default)]
+pub(crate) struct StubResolver {
+    failing: Vec<(String, String)>,
+    resolve_calls: RefCell<Vec<String>>,
+    infra_failure: bool,
+}
 
 impl VersionResolver for StubResolver {
     fn resolve(
         &self,
-        _name: &PackageName,
-        _version: &PackageVersion,
+        name: &PackageName,
+        version: &PackageVersion,
     ) -> Result<ResolvedVersion, NixError> {
+        self.resolve_calls.borrow_mut().push(name.to_string());
+        if self.infra_failure {
+            return Err(NixError::NoExitCode);
+        }
+        if let Some((_, message)) = self.failing.iter().find(|(n, _)| n == name.as_str()) {
+            return Err(NixError::VersionResolution {
+                spec: format!("{}@{}", name, version),
+                message: message.clone(),
+            });
+        }
         Ok(ResolvedVersion {
             commit: "e607cb5".to_string(),
             attr: "go_1_21".to_string(),
@@ -232,6 +247,12 @@ impl VersionResolver for StubResolver {
         _one: bool,
     ) -> Result<String, NixError> {
         Ok("go 1.21.13 nixpkgs/e607cb5#go_1_21".to_string())
+    }
+}
+
+impl StubResolver {
+    pub(crate) fn resolve_calls(&self) -> Vec<String> {
+        self.resolve_calls.borrow().clone()
     }
 }
 
@@ -298,6 +319,19 @@ impl Mocks {
         self
     }
 
+    pub(crate) fn with_failing_versions(mut self, entries: &[(&str, &str)]) -> Self {
+        self.resolver.failing = entries
+            .iter()
+            .map(|(name, message)| (name.to_string(), message.to_string()))
+            .collect();
+        self
+    }
+
+    pub(crate) fn with_resolver_infra_failure(mut self) -> Self {
+        self.resolver.infra_failure = true;
+        self
+    }
+
     fn build(config: Option<DevShellDefinition>) -> Self {
         Self {
             repo: MockRepo {
@@ -309,7 +343,7 @@ impl Mocks {
             scaffolder: MockScaffolder::default(),
             nix: FakeNix::default(),
             nix_eval: StubEvaluator::default(),
-            resolver: StubResolver,
+            resolver: StubResolver::default(),
             out: RecordingOutput::default(),
         }
     }

--- a/crates/lnix-app/src/usecase/lint.rs
+++ b/crates/lnix-app/src/usecase/lint.rs
@@ -1,25 +1,41 @@
 //! `lnix lint` — validate packages via `nix eval`.
 
+use std::collections::HashSet;
+
 use lnix_domain::{
-    PackageName, ValidationResult, classify_nix_eval_error, format_validation_result,
-    format_validation_result_verbose,
+    NixError, PackageName, PackageValidationError, PinnedPackageEntry, ValidationResult,
+    classify_nix_eval_error, format_validation_result, format_validation_result_verbose,
 };
 
 use crate::deps::Deps;
 use crate::error::ApplicationError;
 
-/// Evaluates every channel-based package (stable + unstable) and
-/// prints the validation report. Exit code 1 when any package fails.
+/// Result of verifying pinned entries against the version resolver.
+/// `failed_names` lets the caller exclude broken packages from the
+/// valid-count list without inspecting error variants, keeping the
+/// `if let` fall-through (which is structurally unreachable) out of
+/// coverage reports.
+struct PinnedVerification {
+    failed_names: Vec<String>,
+    errors: Vec<PackageValidationError>,
+}
+
+/// Evaluates every declared package (stable + unstable + pinned) via
+/// `nix eval` and, for pinned entries whose commit/attr are not yet
+/// cached, additionally verifies that the requested version can be
+/// resolved. Read-only: never rewrites `lazynix.yaml`.
+/// Exit code 1 when any package fails.
 pub fn lint(d: &Deps, verbose: bool, arch: Option<&str>) -> Result<i32, ApplicationError> {
     let config = d.repo.read_config()?;
 
     let package = &config.dev_shell.package;
-    let packages: Vec<PackageName> = package
+    let channel_names = package
         .stable
         .iter()
         .chain(package.unstable.iter())
-        .map(|entry| entry.name.clone())
-        .collect();
+        .map(|entry| entry.name.clone());
+    let pinned_names = package.pinned.iter().map(|entry| entry.name.clone());
+    let packages: Vec<PackageName> = channel_names.chain(pinned_names).collect();
 
     if packages.is_empty() {
         d.out.info("No packages to validate.");
@@ -30,13 +46,20 @@ pub fn lint(d: &Deps, verbose: bool, arch: Option<&str>) -> Result<i32, Applicat
 
     let mut valid_packages = Vec::new();
     let mut errors = Vec::new();
+    let mut name_eval_failed = HashSet::new();
     for (name, outcome) in packages.iter().zip(outcomes) {
         if outcome.success {
             valid_packages.push(name.to_string());
         } else {
+            name_eval_failed.insert(name.to_string());
             errors.push(classify_nix_eval_error(name.as_str(), &outcome.stderr));
         }
     }
+
+    let verification = verify_pinned_versions(d, &package.pinned, &name_eval_failed)?;
+    valid_packages.retain(|valid| !verification.failed_names.contains(valid));
+    errors.extend(verification.errors);
+
     let result = ValidationResult {
         valid_packages,
         errors,
@@ -50,6 +73,48 @@ pub fn lint(d: &Deps, verbose: bool, arch: Option<&str>) -> Result<i32, Applicat
     d.out.info(report.trim_end());
 
     Ok(if result.errors.is_empty() { 0 } else { 1 })
+}
+
+/// Verifies pinned entries whose commit/attr are not yet cached and
+/// whose attribute name eval has not already failed. Read-only: never
+/// invokes the config writer, so `lazynix.yaml` is left untouched.
+///
+/// Returns [`PinnedVerification`] pairing each failed package name with
+/// its `VersionNotFound` error, so the caller can update the valid list
+/// without pattern-matching on error variants. Infra failures from the
+/// resolver (anything other than `NixError::VersionResolution`)
+/// short-circuit as `Err`.
+fn verify_pinned_versions(
+    d: &Deps,
+    pinned: &[PinnedPackageEntry],
+    name_eval_failed: &HashSet<String>,
+) -> Result<PinnedVerification, ApplicationError> {
+    let mut failed_names = Vec::new();
+    let mut errors = Vec::new();
+    for entry in pinned {
+        if entry.resolved_commit.is_some() && entry.resolved_attr.is_some() {
+            continue;
+        }
+        if name_eval_failed.contains(entry.name.as_str()) {
+            continue;
+        }
+        match d.resolver.resolve(&entry.name, &entry.version) {
+            Ok(_) => {}
+            Err(NixError::VersionResolution { message, .. }) => {
+                failed_names.push(entry.name.to_string());
+                errors.push(PackageValidationError::VersionNotFound {
+                    package: entry.name.to_string(),
+                    version: entry.version.to_string(),
+                    message,
+                });
+            }
+            Err(other) => return Err(other.into()),
+        }
+    }
+    Ok(PinnedVerification {
+        failed_names,
+        errors,
+    })
 }
 
 #[cfg(test)]
@@ -110,6 +175,169 @@ mod tests {
         let report = m.out.infos().join("\n");
         assert!(report.contains("PACKAGE_NOT_FOUND"));
         assert!(report.contains("ghost-pkg"));
+    }
+
+    #[test]
+    fn pinned_only_config_is_validated_not_skipped() {
+        // Arrange
+        let m = Mocks::with_config(config_from_yaml(
+            "devShell:\n  package:\n    stable: []\n    pinned:\n      - name: go\n        version: \"1.21.13\"\n",
+        ));
+
+        // Act
+        let code = lint(&m.deps(), false, None).unwrap();
+
+        // Assert
+        assert_eq!(code, 0);
+        let infos = m.out.infos();
+        assert!(!infos.contains(&"No packages to validate.".to_string()));
+        assert!(
+            infos
+                .iter()
+                .any(|line| line.contains("✓") && line.contains("1 package(s)"))
+        );
+    }
+
+    #[test]
+    fn pinned_name_that_does_not_exist_reports_categorized_error() {
+        // Arrange
+        let m = Mocks::with_config(config_from_yaml(
+            "devShell:\n  package:\n    stable: []\n    pinned:\n      - name: ghost-pkg\n        version: \"9.9.9\"\n",
+        ))
+        .with_failing_packages(&["ghost-pkg"]);
+
+        // Act
+        let code = lint(&m.deps(), false, None).unwrap();
+
+        // Assert
+        assert_eq!(code, 1);
+        let report = m.out.infos().join("\n");
+        assert!(report.contains("PACKAGE_NOT_FOUND"));
+        assert!(report.contains("ghost-pkg"));
+    }
+
+    #[test]
+    fn stable_and_pinned_are_counted_together_on_success() {
+        // Arrange
+        let m = Mocks::with_config(config_from_yaml(
+            "devShell:\n  package:\n    stable:\n      - name: hello\n    pinned:\n      - name: go\n        version: \"1.21.13\"\n",
+        ));
+
+        // Act
+        let code = lint(&m.deps(), false, None).unwrap();
+
+        // Assert
+        assert_eq!(code, 0);
+        let infos = m.out.infos();
+        assert!(
+            infos
+                .iter()
+                .any(|line| line.contains("✓") && line.contains("2 package(s)"))
+        );
+    }
+
+    #[test]
+    fn cached_pinned_entry_skips_resolver_call() {
+        // Arrange
+        let m = Mocks::with_config(config_from_yaml(
+            "devShell:\n  package:\n    stable: []\n    pinned:\n      - name: go\n        version: \"1.21.13\"\n        resolvedCommit: \"e607cb5\"\n        resolvedAttr: \"go_1_21\"\n",
+        ));
+
+        // Act
+        let code = lint(&m.deps(), false, None).unwrap();
+
+        // Assert
+        assert_eq!(code, 0);
+        assert!(m.resolver.resolve_calls().is_empty());
+    }
+
+    #[test]
+    fn lint_never_persists_config_even_after_resolving_versions() {
+        // Arrange
+        let m = Mocks::with_config(config_from_yaml(
+            "devShell:\n  package:\n    stable: []\n    pinned:\n      - name: go\n        version: \"1.21.13\"\n",
+        ));
+
+        // Act
+        let _ = lint(&m.deps(), false, None).unwrap();
+
+        // Assert
+        assert_eq!(m.resolver.resolve_calls(), vec!["go".to_string()]);
+        assert!(m.repo.persisted_config().is_none());
+    }
+
+    #[test]
+    fn successful_version_resolution_preserves_valid_count_across_stable_and_pinned() {
+        // Arrange
+        let m = Mocks::with_config(config_from_yaml(
+            "devShell:\n  package:\n    stable:\n      - name: hello\n    pinned:\n      - name: go\n        version: \"1.21.13\"\n",
+        ));
+
+        // Act
+        let code = lint(&m.deps(), false, None).unwrap();
+
+        // Assert
+        assert_eq!(code, 0);
+        assert_eq!(m.resolver.resolve_calls(), vec!["go".to_string()]);
+        let infos = m.out.infos();
+        assert!(
+            infos
+                .iter()
+                .any(|line| line.contains("✓") && line.contains("2 package(s)"))
+        );
+    }
+
+    #[test]
+    fn pinned_with_failing_name_eval_skips_resolver_call() {
+        // Arrange
+        let m = Mocks::with_config(config_from_yaml(
+            "devShell:\n  package:\n    stable: []\n    pinned:\n      - name: ghost-pkg\n        version: \"9.9.9\"\n",
+        ))
+        .with_failing_packages(&["ghost-pkg"]);
+
+        // Act
+        let code = lint(&m.deps(), false, None).unwrap();
+
+        // Assert
+        assert_eq!(code, 1);
+        assert!(m.resolver.resolve_calls().is_empty());
+    }
+
+    #[test]
+    fn resolver_infra_failure_propagates_as_application_error() {
+        // Arrange
+        let m = Mocks::with_config(config_from_yaml(
+            "devShell:\n  package:\n    stable: []\n    pinned:\n      - name: go\n        version: \"1.21.13\"\n",
+        ))
+        .with_resolver_infra_failure();
+
+        // Act
+        let result = lint(&m.deps(), false, None);
+
+        // Assert
+        assert!(matches!(
+            result,
+            Err(ApplicationError::Nix(NixError::NoExitCode))
+        ));
+    }
+
+    #[test]
+    fn pinned_version_that_cannot_be_resolved_reports_version_not_found() {
+        // Arrange
+        let m = Mocks::with_config(config_from_yaml(
+            "devShell:\n  package:\n    stable: []\n    pinned:\n      - name: go\n        version: \"9.9.9\"\n",
+        ))
+        .with_failing_versions(&[("go", "no matching commit")]);
+
+        // Act
+        let code = lint(&m.deps(), false, None).unwrap();
+
+        // Assert
+        assert_eq!(code, 1);
+        let report = m.out.infos().join("\n");
+        assert!(report.contains("VERSION_NOT_FOUND"));
+        assert!(report.contains("go"));
+        assert!(report.contains("9.9.9"));
     }
 
     #[test]

--- a/crates/lnix-domain/src/service/lint/error.rs
+++ b/crates/lnix-domain/src/service/lint/error.rs
@@ -21,6 +21,17 @@ pub enum PackageValidationError {
         arch: String,
     },
 
+    /// Pinned version could not be resolved via nix-versions
+    #[error("Version '{version}' of package '{package}' could not be resolved: {message}")]
+    VersionNotFound {
+        /// Name of the package whose version failed to resolve
+        package: String,
+        /// The requested version specifier
+        version: String,
+        /// Why resolution failed (registry stderr or parse detail)
+        message: String,
+    },
+
     /// Unknown error occurred during validation
     #[error("Unknown error for package '{package}': {message}")]
     UnknownError {

--- a/crates/lnix-domain/src/service/lint/report/messages.rs
+++ b/crates/lnix-domain/src/service/lint/report/messages.rs
@@ -10,7 +10,7 @@ pub(super) fn format_success_message(count: usize) -> String {
 
 /// Renders every non-empty error category into one combined report.
 pub(super) fn format_error_sections(errors: &[PackageValidationError]) -> String {
-    let (not_found, arch_unsupported, unknown) = group_errors(errors);
+    let (not_found, arch_unsupported, version_not_found, unknown) = group_errors(errors);
 
     let mut output = String::new();
     if !not_found.is_empty() {
@@ -19,6 +19,10 @@ pub(super) fn format_error_sections(errors: &[PackageValidationError]) -> String
     }
     if !arch_unsupported.is_empty() {
         output.push_str(&format_architecture_unsupported(&arch_unsupported));
+        output.push('\n');
+    }
+    if !version_not_found.is_empty() {
+        output.push_str(&format_version_not_found(&version_not_found));
         output.push('\n');
     }
     if !unknown.is_empty() {
@@ -30,6 +34,7 @@ pub(super) fn format_error_sections(errors: &[PackageValidationError]) -> String
 type ErrorGroups<'a> = (
     Vec<&'a str>,
     Vec<(&'a str, &'a str)>,
+    Vec<(&'a str, &'a str, &'a str)>,
     Vec<(&'a str, &'a str)>,
 );
 
@@ -37,6 +42,7 @@ type ErrorGroups<'a> = (
 fn group_errors(errors: &[PackageValidationError]) -> ErrorGroups<'_> {
     let mut not_found = Vec::new();
     let mut arch_unsupported = Vec::new();
+    let mut version_not_found = Vec::new();
     let mut unknown = Vec::new();
 
     for error in errors {
@@ -45,13 +51,18 @@ fn group_errors(errors: &[PackageValidationError]) -> ErrorGroups<'_> {
             PackageValidationError::ArchitectureUnsupported { package, arch } => {
                 arch_unsupported.push((package.as_str(), arch.as_str()))
             }
+            PackageValidationError::VersionNotFound {
+                package,
+                version,
+                message,
+            } => version_not_found.push((package.as_str(), version.as_str(), message.as_str())),
             PackageValidationError::UnknownError { package, message } => {
                 unknown.push((package.as_str(), message.as_str()))
             }
         }
     }
 
-    (not_found, arch_unsupported, unknown)
+    (not_found, arch_unsupported, version_not_found, unknown)
 }
 
 fn format_package_not_found(packages: &[&str]) -> String {
@@ -84,6 +95,17 @@ fn format_architecture_unsupported(packages: &[(&str, &str)]) -> String {
         }
         output.push_str("\nSee: https://search.nixos.org/packages\n");
     }
+    output
+}
+
+fn format_version_not_found(entries: &[(&str, &str, &str)]) -> String {
+    let mut output = String::new();
+    output.push_str("LazyNix Linting Error: VERSION_NOT_FOUND\n");
+    output.push_str("LazyNix could not resolve pinned version via nix-versions\n\n");
+    for (pkg, version, message) in entries {
+        output.push_str(&format!("- {} @ {}: {}\n", pkg, version, message));
+    }
+    output.push_str("\nSee: run `lnix search <package>` or https://github.com/vic/nix-versions\n");
     output
 }
 
@@ -179,5 +201,33 @@ mod tests {
         assert!(output.contains("UNKNOWN_ERROR"));
         assert!(output.contains("somepkg"));
         assert!(output.contains("strange error"));
+    }
+
+    #[test]
+    fn version_not_found_lists_each_package_version_and_message() {
+        // Arrange
+        let errors = vec![
+            PackageValidationError::VersionNotFound {
+                package: "go".to_string(),
+                version: "9.9.9".to_string(),
+                message: "no matching commit found".to_string(),
+            },
+            PackageValidationError::VersionNotFound {
+                package: "node".to_string(),
+                version: "0.0.0".to_string(),
+                message: "not in registry".to_string(),
+            },
+        ];
+
+        // Act
+        let output = format_error_sections(&errors);
+
+        // Assert
+        assert!(output.contains("VERSION_NOT_FOUND"), "got: {output}");
+        assert!(output.contains("go"), "got: {output}");
+        assert!(output.contains("9.9.9"), "got: {output}");
+        assert!(output.contains("no matching commit found"), "got: {output}");
+        assert!(output.contains("node"), "got: {output}");
+        assert!(output.contains("0.0.0"), "got: {output}");
     }
 }

--- a/document/jp/design/version-pinning.md
+++ b/document/jp/design/version-pinning.md
@@ -242,7 +242,7 @@ $ lnix search go --version ">=1.20" --json --one
 
 - `lnix develop`: pinned パッケージの解決ステップを追加
 - `lnix init`: テンプレートを新スキーマに更新
-- `lnix lint`: pinned パッケージのバリデーションを追加
+- `lnix lint`: pinned パッケージも `nix eval` で name を検証し、未解決の pinned エントリはバージョン解決の可否も検証する (読み取り専用: `lazynix.yaml` は書き換えない)
 
 ---
 
@@ -271,7 +271,9 @@ $ lnix search go --version ">=1.20" --json --one
 
 ### `linter`
 
-- pinned パッケージの lint 対応 (nix eval で存在確認)
+- pinned パッケージの name を `nix eval` で検証 (stable/unstable と同じ経路)
+- 未解決の pinned エントリは resolver でバージョン解決の可否を確認する
+- 読み取り専用: `lazynix.yaml` への書き戻しは行わない
 
 ---
 


### PR DESCRIPTION
## 概要

`lnix lint` が `devShell.package.pinned` を検証せず、存在しない pinned パッケージを見逃したうえ成功件数も誤報告していた問題を修正する。pinned の name を `nix eval` の検証対象に加え、未解決エントリはバージョン解決の可否も検証する。

Closes #58

## 背景

`lnix lint` は「パッケージ名の打ち間違いを `nix develop` の前に捕まえる」ユーザー保護のためのコマンドである (document/en/philosophy.md)。しかし #17 でバージョン固定 (`pinned`) を導入した際、lint は `stable` / `unstable` のみを走査する実装のまま据え置かれ、v0.3.0 の目玉機能である `pinned` だけが lint の保護を受けていなかった。

## 課題

- pinned のみを持つ設定では「No packages to validate.」と報告され、架空のパッケージでも exit 0 で成功していた
- `stable` 1 件 + 架空の `pinned` 1 件の設定では「✓ All 1 package(s) validated successfully!」と表示され、`All` と言いながら設定の 2 パッケージ中 1 つしか見ていない。沈黙して見逃すより積極的に誤解を招く状態だった
- pinned の誤りは `lnix develop` の `NixError::VersionResolution` まで顕在化が遅延していた

## 目標

### 必須項目

- pinned に存在しないパッケージ名・バージョンを書いた場合、`lnix lint` が exit 1 で失敗する
- 成功メッセージの件数が設定に書かれた全パッケージ数と一致する
- lint が `lazynix.yaml` を書き換えない (読み取り専用の維持)

### 範囲外

- pinned バージョン解決の並列化 (Issue #58 の方針どおり、実測してから判断する)

## 採用手法

pinned は「チャンネル上の名前解決」と「特定バージョンの存在確認」の 2 段検証が必要である。name は stable と同じ `nix eval` 経路で検証し、version は `VersionResolver` (nix-versions) への問い合わせで検証する。失敗は新設の `PackageValidationError::VersionNotFound` に変換し、既存のカテゴリ別レポート機構に `VERSION_NOT_FOUND` セクションとして載せる。

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: name は `nix eval`、version は resolver で検証 (採用) | 打ち間違いとバージョン誤りの両方を捕まえ、lint の目的を完全に満たす | resolver 呼び出し分のネットワーク I/O で lint が遅くなる |
| B: name だけ検証し version は見ない | 実装最小 | pinned の主目的がバージョン指定である以上、保護として不十分 |
| C: pinned は対象外のままドキュメントに明記 | 実装変更ゼロ | lint の存在意義が pinned について失われたまま。件数の誤報告も残る |

### 採用理由

pinned を書く動機はバージョン指定そのものであり、バージョンを検証しない lint は保護として中途半端なため案 A を採った。遅延の緩和として、`resolvedCommit` / `resolvedAttr` が揃った解決済みエントリは resolver を呼ばず (develop パイプラインと同じキャッシュ判定)、name の eval に失敗したエントリもスキップして二重報告と無駄な I/O を避けている。resolver のインフラ障害 (`VersionResolution` 以外の `NixError`) は lint の指摘ではなく `ApplicationError` として伝播させ、エラーの層を分けた。

## 変更箇所

- `crates/lnix-app/src/usecase/lint.rs`: pinned の name を検証対象へ追加し、`verify_pinned_versions` ヘルパーでバージョン解決を検証。ドックコメントを実際の検証範囲に更新
- `crates/lnix-domain/src/service/lint/error.rs`: `PackageValidationError::VersionNotFound` 変種を追加
- `crates/lnix-domain/src/service/lint/report/messages.rs`: `VERSION_NOT_FOUND` レポートセクションを追加
- `crates/lnix-app/src/mocks.rs`: `StubResolver` に失敗モード (version 失敗 / インフラ障害) と呼び出し記録を追加
- `document/jp/design/version-pinning.md`: 「lint は pinned 未対応」の残課題記述を実装済みの現状に更新

## 妥協と制限

- **lint の実行時間**: pinned のバージョン検証は `nix-versions` へのネットワーク I/O を伴い、未解決 pinned が多い設定では lint が従来より遅くなる。並列化は実測してから判断する方針とし、本 PR では逐次実行のまま
- **認知的複雑度 (ファイル単位)**: thoughtbot/complexity のスコアは lint.rs 13.95 → 31.41 に上昇したが、主因はテスト 4 → 13 件の増加 (計測がテストを含むファイル単位のため)。テストを除いたプロダクション部分は 6.29 → 10.69 で、新設の検証ループ相当の増分に収まる

## 検証方法

- 単体テスト 9 件を追加: pinned のみの設定 / 架空 name / 架空 version / stable+pinned の件数合算 / 解決済みエントリの resolver スキップ / name 失敗時の resolver スキップ / `write_config` 非呼び出し (読み取り専用性) / インフラ障害の `ApplicationError` 伝播 / `VERSION_NOT_FOUND` レポート描画
- workspace 全テスト pass、`cargo clippy --all-targets -- -D warnings` clean、`cargo fmt --check` clean
- カバレッジ (cargo llvm-cov): lint.rs 100% lines を維持、workspace 全体 95.27% → 95.62%
- 境界・攻撃観点の検証 6 件 (stable/pinned の同名併存、2 回実行の冪等性、複数行エラーメッセージ、部分キャッシュ、キャッシュと失敗の混在等) を scratchpad で実行し全 pass

## 確認事項

- ⚠️ resolver のインフラ障害を lint エラーではなく `ApplicationError` として即時伝播させる設計 (レポートに混ぜない) でよいか
- ⚠️ 本 PR のマージにより #57 の「lint は pinned を検証しない制限をドキュメントに記載する」項目は不要になる。#57 側の記述調整が必要

## 参考文献

- [Issue #58: bug: lnix lint が pinned パッケージを検証せず、成功件数も誤って報告する](https://github.com/shunsock/lazynix/issues/58)
- [Issue #57: docs: README / document / examples / init テンプレートを v0.3.0 に向けて全面改訂する](https://github.com/shunsock/lazynix/issues/57)
- [PR #17: Implement version pinning with flake.nix integration](https://github.com/shunsock/lazynix/pull/17)
- [nix-versions](https://github.com/vic/nix-versions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)