### PR TITLE
feat: add pinned package example to lnix init template

### DIFF
--- a/crates/lnix-infra/templates/lazynix.yaml.template
+++ b/crates/lnix-infra/templates/lazynix.yaml.template
@@ -4,7 +4,13 @@ devShell:
     stable:
       - name: hello
     unstable: []
+    # Optional: Pin a package to a specific version (resolved via nix-versions)
+    # Each entry needs `name` and `version`, NOT a single string like `cowsay_3.0.0`.
+    # Find available versions with: lnix search <name>
+    # To use: replace `pinned: []` below with the commented entries (remove the # marks)
     pinned: []
+    #   - name: go
+    #     version: "1.21.13"
   shellHook:
     - "echo Welcome to LazyNix DevShell!"
 

--- a/crates/lnix-infra/tests/yaml_template_test.rs
+++ b/crates/lnix-infra/tests/yaml_template_test.rs
@@ -1,0 +1,38 @@
+//! Verifies the bundled `lazynix.yaml.template` documents the pinned-package
+//! example so that users can uncomment it into a working configuration. This
+//! lives separately from the `FsProjectScaffolder` unit tests because the
+//! concern (template *content* correctness) is independent of the scaffolder
+//! (which owns *how* the file is written).
+
+use lnix_domain::PinnedPackageEntry;
+
+const YAML_TEMPLATE: &str = include_str!("../templates/lazynix.yaml.template");
+
+fn extract_pinned_example_yaml() -> String {
+    let (_, after) = YAML_TEMPLATE
+        .split_once("    pinned: []\n")
+        .expect("template must contain `pinned: []`");
+    after
+        .lines()
+        .map_while(|line| line.strip_prefix("    # "))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[test]
+fn yaml_template_documents_pinned_usage() {
+    assert!(YAML_TEMPLATE.contains("#   - name: go"));
+    assert!(YAML_TEMPLATE.contains("#     version: \"1.21.13\""));
+    assert!(YAML_TEMPLATE.contains("`name` and `version`"));
+    assert!(YAML_TEMPLATE.contains("NOT a single string"));
+    assert!(YAML_TEMPLATE.contains("lnix search"));
+    assert!(YAML_TEMPLATE.contains("replace `pinned: []`"));
+
+    let example = extract_pinned_example_yaml();
+    let entries: Vec<PinnedPackageEntry> =
+        serde_yaml::from_str(&example).expect("pinned example must parse");
+
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].name.as_str(), "go");
+    assert_eq!(entries[0].version.as_str(), "1.21.13");
+}


### PR DESCRIPTION
## 概要

`lnix init` が生成するテンプレートの `pinned` に、他のオプション項目と同じスタイルのコメント記入例と書式の案内を追加し、初見でも正しい `name`/`version` 形式で書けるようにする。

Closes #24

## 背景

実際に pinned を使おうとしたユーザーが、`stable` の `- name: <pkg>` の感覚で `pinned: [ cowsay_3.0.0 ]` (文字列 1 個) と書いてしまい、内部の Rust 型名を露出する不親切なパースエラー (`invalid type: string "cowsay_3.0.0", expected struct PinnedPackageEntry`) で詰まった。`pinned` は `name` と `version` を持つ構造体で、テンプレート内で最もスキーマが複雑なのに、記入例が無かった。

## 課題

テンプレートのオプション項目のうち `shellAlias` / `env` / `test` にはコメントアウトされた記入例があるのに、`pinned` だけ `pinned: []` の 1 行のみで、正しい書式を知る手がかりがテンプレート内に存在しなかった。

## 目標

### 必須項目

- テンプレートの pinned セクションに正しい `name`/`version` 形式のコメント例がある
- 例が `document/jp/design/version-pinning.md` の記載 (`go` / `1.21.13`) と一致する
- 「文字列 1 個ではなく `name`/`version`」である旨が明示されている
- 利用可能バージョンの調べ方 (`lnix search <name>`) が含まれる

### 範囲外

- パース失敗時のエラーメッセージの親切化 (issue の判断どおり別レイヤーの課題として扱わない)

## 採用手法

テンプレートに記入例コメントを追加し、その記入例が実スキーマから乖離しないことを統合テストで恒久的に保証する。

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: テンプレートにコメント記入例を追加 (採用) | 既存項目と一貫。init 直後に手がかりが得られる。変更が小さい | エラーメッセージ自体は改善しない |
| B: パースエラーメッセージの親切化 | 間違えた瞬間に正解が分かる | 実装コストが大きく、init 時の手がかりという主目的とは別レイヤー |

### 採用理由

A と B は補完関係で、issue が A をスコープとして定義している。さらに実装時の判断として 2 点:

1. **有効化手順を pinned 専用の文言にした。** 既存の定型文「Remove the comment marks (#) to use this feature」を流用せず「To use: replace `pinned: []` below with the commented entries」とした。pinned は他項目と異なり `pinned: []` が生きた行として残るため、`[]` を残したままコメント記号だけ外すと `did not find expected key` という YAML 構文エラーになることをレビュー時に実測で確認しており、定型文の流用はかえって誤誘導になる。
2. **記入例をテストでスキーマに接続した。** 統合テストがコメント解除した記入例を実スキーマ `Vec<PinnedPackageEntry>` としてパースするため、将来スキーマが変わればテストが落ち、記入例が実装から乖離できない。

## 変更箇所

- `crates/lnix-infra/templates/lazynix.yaml.template`: pinned の書式説明・`lnix search` の案内・有効化手順・記入例 (`go` / `1.21.13`) のコメント 6 行を追加
- `crates/lnix-infra/tests/yaml_template_test.rs`: 案内コメントの存在と、記入例が `Vec<PinnedPackageEntry>` としてパース可能なことを検証する統合テストを新設

## 妥協と制限

- **`[]` を残したままのコメント解除は依然エラーになる**: YAML の仕様上避けられないため、テンプレートの案内文で正しい手順 (`pinned: []` を置き換える) を明示する対応とした
- **テンプレート検証を unit テストでなく統合テストに置いた**: テンプレートの「内容の正しさ」はファイルを「どう書き込むか」を担う `FsProjectScaffolder` と独立した関心のため分離した。副次的に、変更ファイルの認知的複雑度をベースラインから悪化させない品質ゲートも満たす (scaffolder.rs は無変更で 7.84 のまま、新テストファイルは 2.65)

## 検証方法

- `nix develop -c cargo test`: ワークスペース全体 0 failures (新統合テスト `yaml_template_documents_pinned_usage` を含む)
- `nix develop -c cargo fmt --check` / `cargo clippy --all-targets`: 差分・警告なし
- `lnix init` を実機実行し、生成された `lazynix.yaml` に記入例コメントが含まれることを確認
- テンプレートそのまま / 正しくコメント解除した状態の両方が実スキーマ (`DevShellDefinition`) でパース可能なことを実測確認

## 確認事項

- ⚠️ 有効化手順の文言を既存の定型文と揃えず pinned 専用にした判断 (上記「採用理由」1)
- ⚠️ 記入例の値 `go` / `1.21.13` を設計ドキュメントと一致させている。ドキュメント側を更新する際はテンプレートと統合テストも追従が必要

## 参考文献

- [Issue #24](https://github.com/shunsock/lazynix/issues/24)
- `document/jp/design/version-pinning.md` (pinned 形式の正典)

🤖 Generated with [Claude Code](https://claude.com/claude-code)