### PR TITLE
refactor: make flake.nix the SSoT for pinned resolutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,9 +194,9 @@ described below.
 - `run`, `task`, and `test` propagate the exit code of the underlying
   child process.
 - `lint` validates `stable`, `unstable`, and `pinned` packages. For
-  `pinned` entries whose `resolvedCommit` / `resolvedAttr` are not
-  yet cached in `lazynix.yaml`, `lint` also asks `nix-versions`
-  whether the requested version can still be resolved.
+  each `pinned` entry, `lint` also asks `nix-versions` whether the
+  requested version can still be resolved, catching typos in the
+  version constraint before the next `lnix develop`.
 
 ## Configuration
 
@@ -276,23 +276,12 @@ Workflow:
            version: "1.21.13"
    ```
 
-3. Run `lnix develop` (or `run`/`test`). LazyNix resolves the pinned
-   entry via `nix-versions`, populates `resolvedCommit` and
-   `resolvedAttr` in the same list entry, and the resolved values are
-   **written back to `lazynix.yaml`** automatically:
-
-   ```yaml
-   devShell:
-     package:
-       pinned:
-         - name: go
-           version: "1.21.13"
-           resolvedCommit: "5ed6275"
-           resolvedAttr: "go_1_21"
-   ```
-
-   Subsequent commands reuse the already-resolved entry and skip the
-   network round-trip.
+3. Run `lnix develop` (or `run`/`test`). LazyNix asks `nix-versions`
+   for the exact `nixpkgs` commit that ships the requested version,
+   then embeds that commit into the generated `flake.nix` as its
+   input URL. Subsequent runs reuse the commit encoded in `flake.nix`
+   and skip the resolver call — the `flake.nix` **is** the cache.
+   `lazynix.yaml` is never touched.
 
 ### 🔤 Shell Aliases
 

--- a/crates/lnix-app/src/deps.rs
+++ b/crates/lnix-app/src/deps.rs
@@ -17,10 +17,10 @@ use lnix_domain::interface::persistence::{
 /// The composition root (the binary) owns the adapter values; `Deps`
 /// only borrows them for the duration of one command.
 pub struct Deps<'a> {
-    /// Reads/writes `lazynix.yaml` and reads `lazynix-settings.yaml`.
+    /// Reads `lazynix.yaml` and `lazynix-settings.yaml`.
     pub repo: &'a dyn ConfigRepository,
     /// Persists rendered `flake.nix` content.
-    pub writer: &'a dyn FlakeWriter,
+    pub flake_writer: &'a dyn FlakeWriter,
     /// Recovers pinned `(commit, attr)` from the existing `flake.nix`.
     pub flake_reader: &'a dyn FlakeReader,
     /// Checks dotenv files referenced by the config exist.
@@ -49,7 +49,7 @@ mod tests {
         let deps = m.deps();
 
         let config = deps.repo.read_config().unwrap();
-        let write_result = deps.writer.write_flake("{}");
+        let write_result = deps.flake_writer.write_flake("{}");
         let pinned = deps.flake_reader.read_pinned_inputs().unwrap();
         let env_exists = deps.env.exists(".env");
         let exit_code = deps.nix.develop_command(&["true".to_string()]).unwrap();

--- a/crates/lnix-app/src/deps.rs
+++ b/crates/lnix-app/src/deps.rs
@@ -9,7 +9,7 @@
 use lnix_domain::interface::gateway::{NixEvaluator, NixRunner, VersionResolver};
 use lnix_domain::interface::output::OutputPort;
 use lnix_domain::interface::persistence::{
-    ConfigRepository, EnvFilePresenceChecker, FlakeWriter, ProjectScaffolder,
+    ConfigRepository, EnvFilePresenceChecker, FlakeReader, FlakeWriter, ProjectScaffolder,
 };
 
 /// Borrowed bundle of every port a use-case may touch.
@@ -21,6 +21,8 @@ pub struct Deps<'a> {
     pub repo: &'a dyn ConfigRepository,
     /// Persists rendered `flake.nix` content.
     pub writer: &'a dyn FlakeWriter,
+    /// Recovers pinned `(commit, attr)` from the existing `flake.nix`.
+    pub flake_reader: &'a dyn FlakeReader,
     /// Checks dotenv files referenced by the config exist.
     pub env: &'a dyn EnvFilePresenceChecker,
     /// Writes the bundled starter files for `lnix init`.
@@ -39,20 +41,16 @@ pub struct Deps<'a> {
 mod tests {
     use crate::mocks::*;
 
-    // Building Deps from the shared mocks is itself the assertion that
-    // every port trait stays object-safe (a generic method would break
-    // `dyn`).
     #[test]
     fn bundles_all_ports_and_dispatches_through_dyn() {
-        // Arrange
         let m = Mocks::with_config(config_from_yaml(
             "devShell:\n  package:\n    stable:\n      - name: bash\n",
         ));
         let deps = m.deps();
 
-        // Act
         let config = deps.repo.read_config().unwrap();
         let write_result = deps.writer.write_flake("{}");
+        let pinned = deps.flake_reader.read_pinned_inputs().unwrap();
         let env_exists = deps.env.exists(".env");
         let exit_code = deps.nix.develop_command(&["true".to_string()]).unwrap();
         let outcome = deps
@@ -65,9 +63,9 @@ mod tests {
             .unwrap();
         deps.out.info("progress");
 
-        // Assert
         assert_eq!(config.dev_shell.package.stable[0].name.as_str(), "bash");
         assert!(write_result.is_ok());
+        assert!(pinned.is_empty());
         assert!(env_exists);
         assert_eq!(exit_code, 0);
         assert!(outcome.success);

--- a/crates/lnix-app/src/mocks.rs
+++ b/crates/lnix-app/src/mocks.rs
@@ -4,17 +4,15 @@
 //! a test is: build `Mocks`, run the use-case, assert on recordings.
 //! No filesystem, no subprocess, no terminal.
 
-use std::cell::RefCell;
-
-use std::collections::HashMap;
+use std::{cell::RefCell, collections::HashMap};
 
 use lnix_domain::interface::gateway::{
     EvalOutcome, NixEvaluator, NixRunner, ResolvedVersion, VersionResolver,
 };
 use lnix_domain::interface::output::OutputPort;
 use lnix_domain::interface::persistence::{
-    ConfigRepository, EnvFilePresenceChecker, FlakeReader, FlakeWriter, PinnedResolutions,
-    ProjectScaffolder,
+    ConfigRepository, EnvFilePresenceChecker, FlakeReader, FlakeWriter, PinnedResolution,
+    PinnedResolutions, ProjectScaffolder,
 };
 use lnix_domain::{
     ConfigError, DevShellDefinition, FlakeError, NixError, PackageName, PackageVersion, Settings,
@@ -28,7 +26,6 @@ pub(crate) fn config_from_yaml(yaml: &str) -> DevShellDefinition {
 
 pub(crate) struct MockRepo {
     config: Option<DevShellDefinition>,
-    persisted: RefCell<Option<DevShellDefinition>>,
 }
 
 impl ConfigRepository for MockRepo {
@@ -38,19 +35,8 @@ impl ConfigRepository for MockRepo {
             .ok_or_else(|| ConfigError::NotFound(".".to_string()))
     }
 
-    fn write_config(&self, config: &DevShellDefinition) -> Result<(), ConfigError> {
-        *self.persisted.borrow_mut() = Some(config.clone());
-        Ok(())
-    }
-
     fn read_settings(&self) -> Result<Option<Settings>, ConfigError> {
         Ok(None)
-    }
-}
-
-impl MockRepo {
-    pub(crate) fn persisted_config(&self) -> Option<DevShellDefinition> {
-        self.persisted.borrow().clone()
     }
 }
 
@@ -259,6 +245,7 @@ impl StubResolver {
     }
 }
 
+#[derive(Default)]
 pub(crate) struct MockFlakeReader {
     inputs: PinnedResolutions,
     read_calls: RefCell<u32>,
@@ -281,21 +268,12 @@ impl MockFlakeReader {
     pub(crate) fn new(inputs: PinnedResolutions) -> Self {
         Self {
             inputs,
-            read_calls: RefCell::new(0),
-            should_fail: false,
+            ..Self::default()
         }
     }
 
     pub(crate) fn empty() -> Self {
-        Self::new(HashMap::new())
-    }
-
-    pub(crate) fn failing() -> Self {
-        Self {
-            inputs: HashMap::new(),
-            read_calls: RefCell::new(0),
-            should_fail: true,
-        }
+        Self::default()
     }
 
     pub(crate) fn read_calls(&self) -> u32 {
@@ -332,7 +310,7 @@ impl RecordingOutput {
 /// One mock per port, lent out as a [`Deps`].
 pub(crate) struct Mocks {
     pub(crate) repo: MockRepo,
-    pub(crate) writer: SpyWriter,
+    pub(crate) flake_writer: SpyWriter,
     pub(crate) flake_reader: MockFlakeReader,
     pub(crate) env: StubEnvChecker,
     pub(crate) scaffolder: MockScaffolder,
@@ -385,13 +363,18 @@ impl Mocks {
         self
     }
 
+    pub(crate) fn with_failing_flake_reader(mut self) -> Self {
+        self.flake_reader = MockFlakeReader {
+            should_fail: true,
+            ..MockFlakeReader::default()
+        };
+        self
+    }
+
     fn build(config: Option<DevShellDefinition>) -> Self {
         Self {
-            repo: MockRepo {
-                config,
-                persisted: RefCell::new(None),
-            },
-            writer: SpyWriter::default(),
+            repo: MockRepo { config },
+            flake_writer: SpyWriter::default(),
             flake_reader: MockFlakeReader::empty(),
             env: StubEnvChecker { all_present: true },
             scaffolder: MockScaffolder::default(),
@@ -405,7 +388,7 @@ impl Mocks {
     pub(crate) fn deps(&self) -> Deps<'_> {
         Deps {
             repo: &self.repo,
-            writer: &self.writer,
+            flake_writer: &self.flake_writer,
             flake_reader: &self.flake_reader,
             env: &self.env,
             scaffolder: &self.scaffolder,
@@ -426,7 +409,10 @@ mod tests {
         let mut inputs: PinnedResolutions = HashMap::new();
         inputs.insert(
             ("go".parse().unwrap(), "1.21.13".parse().unwrap()),
-            ("5ed6275".into(), "go_1_21".into()),
+            PinnedResolution {
+                commit: "5ed6275".into(),
+                attr: "go_1_21".into(),
+            },
         );
         let reader = MockFlakeReader::new(inputs.clone());
 

--- a/crates/lnix-app/src/mocks.rs
+++ b/crates/lnix-app/src/mocks.rs
@@ -6,12 +6,15 @@
 
 use std::cell::RefCell;
 
+use std::collections::HashMap;
+
 use lnix_domain::interface::gateway::{
     EvalOutcome, NixEvaluator, NixRunner, ResolvedVersion, VersionResolver,
 };
 use lnix_domain::interface::output::OutputPort;
 use lnix_domain::interface::persistence::{
-    ConfigRepository, EnvFilePresenceChecker, FlakeWriter, ProjectScaffolder,
+    ConfigRepository, EnvFilePresenceChecker, FlakeReader, FlakeWriter, PinnedResolutions,
+    ProjectScaffolder,
 };
 use lnix_domain::{
     ConfigError, DevShellDefinition, FlakeError, NixError, PackageName, PackageVersion, Settings,
@@ -256,6 +259,50 @@ impl StubResolver {
     }
 }
 
+pub(crate) struct MockFlakeReader {
+    inputs: PinnedResolutions,
+    read_calls: RefCell<u32>,
+    should_fail: bool,
+}
+
+impl FlakeReader for MockFlakeReader {
+    fn read_pinned_inputs(&self) -> Result<PinnedResolutions, FlakeError> {
+        *self.read_calls.borrow_mut() += 1;
+        if self.should_fail {
+            return Err(FlakeError::Read(std::io::Error::other(
+                "mock flake reader failure",
+            )));
+        }
+        Ok(self.inputs.clone())
+    }
+}
+
+impl MockFlakeReader {
+    pub(crate) fn new(inputs: PinnedResolutions) -> Self {
+        Self {
+            inputs,
+            read_calls: RefCell::new(0),
+            should_fail: false,
+        }
+    }
+
+    pub(crate) fn empty() -> Self {
+        Self::new(HashMap::new())
+    }
+
+    pub(crate) fn failing() -> Self {
+        Self {
+            inputs: HashMap::new(),
+            read_calls: RefCell::new(0),
+            should_fail: true,
+        }
+    }
+
+    pub(crate) fn read_calls(&self) -> u32 {
+        *self.read_calls.borrow()
+    }
+}
+
 #[derive(Default)]
 pub(crate) struct RecordingOutput {
     infos: RefCell<Vec<String>>,
@@ -286,6 +333,7 @@ impl RecordingOutput {
 pub(crate) struct Mocks {
     pub(crate) repo: MockRepo,
     pub(crate) writer: SpyWriter,
+    pub(crate) flake_reader: MockFlakeReader,
     pub(crate) env: StubEnvChecker,
     pub(crate) scaffolder: MockScaffolder,
     pub(crate) nix: FakeNix,
@@ -332,6 +380,11 @@ impl Mocks {
         self
     }
 
+    pub(crate) fn with_flake_reader(mut self, reader: MockFlakeReader) -> Self {
+        self.flake_reader = reader;
+        self
+    }
+
     fn build(config: Option<DevShellDefinition>) -> Self {
         Self {
             repo: MockRepo {
@@ -339,6 +392,7 @@ impl Mocks {
                 persisted: RefCell::new(None),
             },
             writer: SpyWriter::default(),
+            flake_reader: MockFlakeReader::empty(),
             env: StubEnvChecker { all_present: true },
             scaffolder: MockScaffolder::default(),
             nix: FakeNix::default(),
@@ -352,6 +406,7 @@ impl Mocks {
         Deps {
             repo: &self.repo,
             writer: &self.writer,
+            flake_reader: &self.flake_reader,
             env: &self.env,
             scaffolder: &self.scaffolder,
             nix: &self.nix,
@@ -359,5 +414,41 @@ impl Mocks {
             resolver: &self.resolver,
             out: &self.out,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mock_flake_reader_returns_configured_inputs() {
+        let mut inputs: PinnedResolutions = HashMap::new();
+        inputs.insert(
+            ("go".parse().unwrap(), "1.21.13".parse().unwrap()),
+            ("5ed6275".into(), "go_1_21".into()),
+        );
+        let reader = MockFlakeReader::new(inputs.clone());
+
+        assert_eq!(reader.read_pinned_inputs().unwrap(), inputs);
+    }
+
+    #[test]
+    fn mock_flake_reader_records_read_calls() {
+        let reader = MockFlakeReader::empty();
+
+        let _ = reader.read_pinned_inputs();
+        let _ = reader.read_pinned_inputs();
+
+        assert_eq!(reader.read_calls(), 2);
+    }
+
+    #[test]
+    fn mocks_with_config_defaults_flake_reader_to_empty() {
+        let m = Mocks::with_config(config_from_yaml(
+            "devShell:\n  package:\n    stable:\n      - name: bash\n",
+        ));
+
+        assert!(m.flake_reader.read_pinned_inputs().unwrap().is_empty());
     }
 }

--- a/crates/lnix-app/src/pipeline.rs
+++ b/crates/lnix-app/src/pipeline.rs
@@ -57,15 +57,21 @@ fn validate_env_files(d: &Deps, config: &DevShellDefinition) -> Result<(), Appli
     Ok(())
 }
 
-/// Resolves pinned package versions and persists any newly resolved
-/// entries back to `lazynix.yaml`.
+/// Populates each pinned entry with its resolved `(commit, attr)`,
+/// preferring the rendered `flake.nix` as the source of truth and
+/// falling back to the version resolver for cache misses. Never
+/// rewrites `lazynix.yaml`; the flake and lockfile are the durable
+/// record.
 fn resolve_pinned_packages(
     d: &Deps,
     config: &mut DevShellDefinition,
 ) -> Result<(), ApplicationError> {
-    let mut resolved_any = false;
+    let cached = d.flake_reader.read_pinned_inputs()?;
     for entry in &mut config.dev_shell.package.pinned {
-        if entry.resolved_commit.is_some() && entry.resolved_attr.is_some() {
+        let key = (entry.name.clone(), entry.version.clone());
+        if let Some((commit, attr)) = cached.get(&key) {
+            entry.resolved_commit = Some(commit.clone());
+            entry.resolved_attr = Some(attr.clone());
             continue;
         }
         d.out.info(&format!(
@@ -75,12 +81,6 @@ fn resolve_pinned_packages(
         let resolved = d.resolver.resolve(&entry.name, &entry.version)?;
         entry.resolved_commit = Some(resolved.commit);
         entry.resolved_attr = Some(resolved.attr);
-        resolved_any = true;
-    }
-
-    if resolved_any {
-        d.repo.write_config(config)?;
-        d.out.info("Updated lazynix.yaml with resolved versions");
     }
     Ok(())
 }
@@ -105,4 +105,134 @@ pub(crate) fn maybe_update_lock(d: &Deps, update_lock: bool) -> Result<(), Appli
             .info("Skipping flake.lock update (use --update to update)");
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mocks::*;
+    use lnix_domain::interface::persistence::{ConfigRepository, PinnedResolutions};
+    use std::collections::HashMap;
+
+    fn config_with_pinned(entries: &[(&str, &str)]) -> DevShellDefinition {
+        let mut yaml = String::from("devShell:\n  package:\n    stable: []\n    pinned:\n");
+        for (name, version) in entries {
+            yaml.push_str(&format!(
+                "      - name: {}\n        version: \"{}\"\n",
+                name, version
+            ));
+        }
+        config_from_yaml(&yaml)
+    }
+
+    fn cache(entries: &[(&str, &str, &str, &str)]) -> PinnedResolutions {
+        let mut inputs: PinnedResolutions = HashMap::new();
+        for (name, version, commit, attr) in entries {
+            inputs.insert(
+                (name.parse().unwrap(), version.parse().unwrap()),
+                ((*commit).to_string(), (*attr).to_string()),
+            );
+        }
+        inputs
+    }
+
+    #[test]
+    fn cache_hit_skips_resolver() {
+        let m = Mocks::with_config(config_with_pinned(&[("go", "1.21.13")])).with_flake_reader(
+            MockFlakeReader::new(cache(&[("go", "1.21.13", "5ed6275", "go_1_21")])),
+        );
+        let mut config = m.repo.read_config().unwrap();
+
+        resolve_pinned_packages(&m.deps(), &mut config).unwrap();
+
+        assert!(m.resolver.resolve_calls().is_empty());
+        let pinned = &config.dev_shell.package.pinned[0];
+        assert_eq!(pinned.resolved_commit.as_deref(), Some("5ed6275"));
+        assert_eq!(pinned.resolved_attr.as_deref(), Some("go_1_21"));
+        assert!(m.repo.persisted_config().is_none());
+    }
+
+    #[test]
+    fn cache_miss_calls_resolver() {
+        let m = Mocks::with_config(config_with_pinned(&[("go", "1.21.13")]))
+            .with_flake_reader(MockFlakeReader::empty());
+        let mut config = m.repo.read_config().unwrap();
+
+        resolve_pinned_packages(&m.deps(), &mut config).unwrap();
+
+        assert_eq!(m.resolver.resolve_calls(), vec!["go".to_string()]);
+        let pinned = &config.dev_shell.package.pinned[0];
+        assert_eq!(pinned.resolved_commit.as_deref(), Some("e607cb5"));
+        assert_eq!(pinned.resolved_attr.as_deref(), Some("go_1_21"));
+        assert!(m.repo.persisted_config().is_none());
+    }
+
+    #[test]
+    fn no_pinned_entries_no_resolver_calls() {
+        let m = Mocks::with_config(config_from_yaml("devShell:\n  package:\n    stable: []\n"));
+        let mut config = m.repo.read_config().unwrap();
+
+        resolve_pinned_packages(&m.deps(), &mut config).unwrap();
+
+        assert!(m.resolver.resolve_calls().is_empty());
+        assert!(m.repo.persisted_config().is_none());
+    }
+
+    #[test]
+    fn flake_reader_error_propagates_as_application_error() {
+        let m = Mocks::with_config(config_with_pinned(&[("go", "1.21.13")]))
+            .with_flake_reader(MockFlakeReader::failing());
+        let mut config = m.repo.read_config().unwrap();
+
+        let result = resolve_pinned_packages(&m.deps(), &mut config);
+
+        assert!(matches!(
+            result,
+            Err(ApplicationError::Flake(lnix_domain::FlakeError::Read(_)))
+        ));
+        assert!(m.resolver.resolve_calls().is_empty());
+        assert!(m.repo.persisted_config().is_none());
+    }
+
+    #[test]
+    fn already_resolved_inline_still_uses_cache() {
+        let m = Mocks::with_config(config_from_yaml(
+            "devShell:\n  package:\n    stable: []\n    pinned:\n      - name: go\n        version: \"1.21.13\"\n        resolvedCommit: OLD\n        resolvedAttr: OLD\n",
+        ))
+        .with_flake_reader(MockFlakeReader::new(cache(&[(
+            "go", "1.21.13", "NEW_COMMIT", "NEW_ATTR",
+        )])));
+        let mut config = m.repo.read_config().unwrap();
+
+        resolve_pinned_packages(&m.deps(), &mut config).unwrap();
+
+        assert!(m.resolver.resolve_calls().is_empty());
+        let pinned = &config.dev_shell.package.pinned[0];
+        assert_eq!(pinned.resolved_commit.as_deref(), Some("NEW_COMMIT"));
+        assert_eq!(pinned.resolved_attr.as_deref(), Some("NEW_ATTR"));
+        assert!(m.repo.persisted_config().is_none());
+    }
+
+    #[test]
+    fn partial_cache_only_resolves_missing() {
+        let m = Mocks::with_config(config_with_pinned(&[("go", "1.21.13"), ("rust", "1.70.0")]))
+            .with_flake_reader(MockFlakeReader::new(cache(&[(
+                "go",
+                "1.21.13",
+                "5ed6275",
+                "go_1_21_cached",
+            )])));
+        let mut config = m.repo.read_config().unwrap();
+
+        resolve_pinned_packages(&m.deps(), &mut config).unwrap();
+
+        assert_eq!(m.resolver.resolve_calls(), vec!["rust".to_string()]);
+        let go = &config.dev_shell.package.pinned[0];
+        assert_eq!(go.resolved_commit.as_deref(), Some("5ed6275"));
+        assert_eq!(go.resolved_attr.as_deref(), Some("go_1_21_cached"));
+        let rust = &config.dev_shell.package.pinned[1];
+        assert_eq!(rust.resolved_commit.as_deref(), Some("e607cb5"));
+        assert_eq!(rust.resolved_attr.as_deref(), Some("go_1_21"));
+        assert!(m.repo.persisted_config().is_none());
+    }
 }

--- a/crates/lnix-app/src/pipeline.rs
+++ b/crates/lnix-app/src/pipeline.rs
@@ -19,24 +19,24 @@ pub(crate) struct LoadedConfig {
 
 /// Reads, validates, and resolves the config — everything needed before
 /// rendering, but without writing `flake.nix` yet.
-pub(crate) fn load_config(d: &Deps) -> Result<LoadedConfig, ApplicationError> {
-    let settings = d.repo.read_settings()?;
+pub(crate) fn load_config(deps: &Deps) -> Result<LoadedConfig, ApplicationError> {
+    let settings = deps.repo.read_settings()?;
     let override_url = settings
         .and_then(|s| s.override_stable_package)
         .map(|url| url.as_str().to_string());
 
-    d.out.info("Reading configuration...");
-    let mut config = d.repo.read_config()?;
+    deps.out.info("Reading configuration...");
+    let mut config = deps.repo.read_config()?;
 
-    d.out.info("Validating configuration...");
+    deps.out.info("Validating configuration...");
     for diagnostic in
         lnix_domain::validate_config(&config).map_err(lnix_domain::ConfigError::from)?
     {
-        d.out.warn(&diagnostic.to_string());
+        deps.out.warn(&diagnostic.to_string());
     }
-    validate_env_files(d, &config)?;
+    validate_env_files(deps, &config)?;
 
-    resolve_pinned_packages(d, &mut config)?;
+    resolve_pinned_packages(deps, &mut config)?;
 
     Ok(LoadedConfig {
         config,
@@ -45,12 +45,12 @@ pub(crate) fn load_config(d: &Deps) -> Result<LoadedConfig, ApplicationError> {
 }
 
 /// Fails when a dotenv file referenced by the config does not exist.
-fn validate_env_files(d: &Deps, config: &DevShellDefinition) -> Result<(), ApplicationError> {
+fn validate_env_files(deps: &Deps, config: &DevShellDefinition) -> Result<(), ApplicationError> {
     let Some(env) = &config.dev_shell.env else {
         return Ok(());
     };
     for dotenv_path in &env.dotenv {
-        if !d.env.exists(dotenv_path) {
+        if !deps.env.exists(dotenv_path) {
             return Err(lnix_domain::ConfigError::DotenvFileNotFound(dotenv_path.clone()).into());
         }
     }
@@ -60,25 +60,33 @@ fn validate_env_files(d: &Deps, config: &DevShellDefinition) -> Result<(), Appli
 /// Populates each pinned entry with its resolved `(commit, attr)`,
 /// preferring the rendered `flake.nix` as the source of truth and
 /// falling back to the version resolver for cache misses. Never
-/// rewrites `lazynix.yaml`; the flake and lockfile are the durable
-/// record.
+/// rewrites `lazynix.yaml`; the generated `flake.nix` and `flake.lock`
+/// are the durable record.
+// NOTE: if the resolver errors mid-loop the caller's config is left
+// in a partially-mutated state; safe today because load_config aborts.
 fn resolve_pinned_packages(
-    d: &Deps,
+    deps: &Deps,
     config: &mut DevShellDefinition,
 ) -> Result<(), ApplicationError> {
-    let cached = d.flake_reader.read_pinned_inputs()?;
+    let mut cached = deps.flake_reader.read_pinned_inputs()?;
     for entry in &mut config.dev_shell.package.pinned {
+        if entry.version.as_str().contains('-') {
+            deps.out.warn(&format!(
+                "Version '{}' for '{}' contains '-' which conflicts with the pinned-input separator; skipping flake.nix cache and re-resolving via nix-versions each run.",
+                entry.version, entry.name
+            ));
+        }
         let key = (entry.name.clone(), entry.version.clone());
-        if let Some((commit, attr)) = cached.get(&key) {
-            entry.resolved_commit = Some(commit.clone());
-            entry.resolved_attr = Some(attr.clone());
+        if let Some(resolution) = cached.remove(&key) {
+            entry.resolved_commit = Some(resolution.commit);
+            entry.resolved_attr = Some(resolution.attr);
             continue;
         }
-        d.out.info(&format!(
+        deps.out.info(&format!(
             "Resolving version for {} @ {}...",
             entry.name, entry.version
         ));
-        let resolved = d.resolver.resolve(&entry.name, &entry.version)?;
+        let resolved = deps.resolver.resolve(&entry.name, &entry.version)?;
         entry.resolved_commit = Some(resolved.commit);
         entry.resolved_attr = Some(resolved.attr);
     }
@@ -86,22 +94,22 @@ fn resolve_pinned_packages(
 }
 
 /// Renders the loaded config and persists it as `flake.nix`.
-pub(crate) fn write_flake(d: &Deps, loaded: &LoadedConfig) -> Result<(), ApplicationError> {
-    d.out.info("Generating flake.nix...");
+pub(crate) fn write_flake(deps: &Deps, loaded: &LoadedConfig) -> Result<(), ApplicationError> {
+    deps.out.info("Generating flake.nix...");
     let contents = render_flake(&loaded.config, loaded.override_url.as_deref());
-    d.writer.write_flake(&contents)?;
-    d.out.info("✓ flake.nix generated successfully");
+    deps.flake_writer.write_flake(&contents)?;
+    deps.out.info("✓ flake.nix generated successfully");
     Ok(())
 }
 
 /// Updates `flake.lock` when requested, or reports that it was skipped.
-pub(crate) fn maybe_update_lock(d: &Deps, update_lock: bool) -> Result<(), ApplicationError> {
+pub(crate) fn maybe_update_lock(deps: &Deps, update_lock: bool) -> Result<(), ApplicationError> {
     if update_lock {
-        d.out.info("Updating flake.lock...");
-        d.nix.flake_update()?;
-        d.out.info("flake.lock updated successfully");
+        deps.out.info("Updating flake.lock...");
+        deps.nix.flake_update()?;
+        deps.out.info("flake.lock updated successfully");
     } else {
-        d.out
+        deps.out
             .info("Skipping flake.lock update (use --update to update)");
     }
     Ok(())
@@ -111,7 +119,9 @@ pub(crate) fn maybe_update_lock(d: &Deps, update_lock: bool) -> Result<(), Appli
 mod tests {
     use super::*;
     use crate::mocks::*;
-    use lnix_domain::interface::persistence::{ConfigRepository, PinnedResolutions};
+    use lnix_domain::interface::persistence::{
+        ConfigRepository, PinnedResolution, PinnedResolutions,
+    };
     use std::collections::HashMap;
 
     fn config_with_pinned(entries: &[(&str, &str)]) -> DevShellDefinition {
@@ -125,12 +135,15 @@ mod tests {
         config_from_yaml(&yaml)
     }
 
-    fn cache(entries: &[(&str, &str, &str, &str)]) -> PinnedResolutions {
+    fn resolutions_from(entries: &[(&str, &str, &str, &str)]) -> PinnedResolutions {
         let mut inputs: PinnedResolutions = HashMap::new();
         for (name, version, commit, attr) in entries {
             inputs.insert(
                 (name.parse().unwrap(), version.parse().unwrap()),
-                ((*commit).to_string(), (*attr).to_string()),
+                PinnedResolution {
+                    commit: (*commit).to_string(),
+                    attr: (*attr).to_string(),
+                },
             );
         }
         inputs
@@ -139,7 +152,7 @@ mod tests {
     #[test]
     fn cache_hit_skips_resolver() {
         let m = Mocks::with_config(config_with_pinned(&[("go", "1.21.13")])).with_flake_reader(
-            MockFlakeReader::new(cache(&[("go", "1.21.13", "5ed6275", "go_1_21")])),
+            MockFlakeReader::new(resolutions_from(&[("go", "1.21.13", "5ed6275", "go_1_21")])),
         );
         let mut config = m.repo.read_config().unwrap();
 
@@ -149,7 +162,6 @@ mod tests {
         let pinned = &config.dev_shell.package.pinned[0];
         assert_eq!(pinned.resolved_commit.as_deref(), Some("5ed6275"));
         assert_eq!(pinned.resolved_attr.as_deref(), Some("go_1_21"));
-        assert!(m.repo.persisted_config().is_none());
     }
 
     #[test]
@@ -164,7 +176,6 @@ mod tests {
         let pinned = &config.dev_shell.package.pinned[0];
         assert_eq!(pinned.resolved_commit.as_deref(), Some("e607cb5"));
         assert_eq!(pinned.resolved_attr.as_deref(), Some("go_1_21"));
-        assert!(m.repo.persisted_config().is_none());
     }
 
     #[test]
@@ -175,13 +186,12 @@ mod tests {
         resolve_pinned_packages(&m.deps(), &mut config).unwrap();
 
         assert!(m.resolver.resolve_calls().is_empty());
-        assert!(m.repo.persisted_config().is_none());
     }
 
     #[test]
     fn flake_reader_error_propagates_as_application_error() {
         let m = Mocks::with_config(config_with_pinned(&[("go", "1.21.13")]))
-            .with_flake_reader(MockFlakeReader::failing());
+            .with_failing_flake_reader();
         let mut config = m.repo.read_config().unwrap();
 
         let result = resolve_pinned_packages(&m.deps(), &mut config);
@@ -191,7 +201,6 @@ mod tests {
             Err(ApplicationError::Flake(lnix_domain::FlakeError::Read(_)))
         ));
         assert!(m.resolver.resolve_calls().is_empty());
-        assert!(m.repo.persisted_config().is_none());
     }
 
     #[test]
@@ -199,7 +208,7 @@ mod tests {
         let m = Mocks::with_config(config_from_yaml(
             "devShell:\n  package:\n    stable: []\n    pinned:\n      - name: go\n        version: \"1.21.13\"\n        resolvedCommit: OLD\n        resolvedAttr: OLD\n",
         ))
-        .with_flake_reader(MockFlakeReader::new(cache(&[(
+        .with_flake_reader(MockFlakeReader::new(resolutions_from(&[(
             "go", "1.21.13", "NEW_COMMIT", "NEW_ATTR",
         )])));
         let mut config = m.repo.read_config().unwrap();
@@ -210,13 +219,27 @@ mod tests {
         let pinned = &config.dev_shell.package.pinned[0];
         assert_eq!(pinned.resolved_commit.as_deref(), Some("NEW_COMMIT"));
         assert_eq!(pinned.resolved_attr.as_deref(), Some("NEW_ATTR"));
-        assert!(m.repo.persisted_config().is_none());
+    }
+
+    #[test]
+    fn hyphen_in_version_cache_miss_is_ok() {
+        let m = Mocks::with_config(config_with_pinned(&[("go", "1.0.0-rc1")]))
+            .with_flake_reader(MockFlakeReader::empty());
+        let mut config = m.repo.read_config().unwrap();
+
+        resolve_pinned_packages(&m.deps(), &mut config).unwrap();
+
+        assert_eq!(m.resolver.resolve_calls(), vec!["go".to_string()]);
+        let warns = m.out.warns().join("\n");
+        assert!(warns.contains("1.0.0-rc1"));
+        let pinned = &config.dev_shell.package.pinned[0];
+        assert_eq!(pinned.resolved_commit.as_deref(), Some("e607cb5"));
     }
 
     #[test]
     fn partial_cache_only_resolves_missing() {
         let m = Mocks::with_config(config_with_pinned(&[("go", "1.21.13"), ("rust", "1.70.0")]))
-            .with_flake_reader(MockFlakeReader::new(cache(&[(
+            .with_flake_reader(MockFlakeReader::new(resolutions_from(&[(
                 "go",
                 "1.21.13",
                 "5ed6275",
@@ -233,6 +256,5 @@ mod tests {
         let rust = &config.dev_shell.package.pinned[1];
         assert_eq!(rust.resolved_commit.as_deref(), Some("e607cb5"));
         assert_eq!(rust.resolved_attr.as_deref(), Some("go_1_21"));
-        assert!(m.repo.persisted_config().is_none());
     }
 }

--- a/crates/lnix-app/src/usecase/develop.rs
+++ b/crates/lnix-app/src/usecase/develop.rs
@@ -32,7 +32,7 @@ mod tests {
         let code = develop(&m.deps(), false).unwrap();
 
         assert_eq!(code, 0);
-        assert!(m.writer.written().unwrap().contains("bash"));
+        assert!(m.flake_writer.written().unwrap().contains("bash"));
         assert_eq!(m.nix.develop_calls(), 1);
         assert!(
             m.out
@@ -73,7 +73,7 @@ mod tests {
             result,
             Err(ApplicationError::Config(ConfigError::NotFound(_)))
         ));
-        assert!(m.writer.written().is_none());
+        assert!(m.flake_writer.written().is_none());
         assert_eq!(m.nix.develop_calls(), 0);
     }
 
@@ -90,7 +90,7 @@ mod tests {
             result,
             Err(ApplicationError::Config(ConfigError::DotenvFileNotFound(_)))
         ));
-        assert!(m.writer.written().is_none());
+        assert!(m.flake_writer.written().is_none());
     }
 
     #[test]
@@ -101,10 +101,12 @@ mod tests {
 
         develop(&m.deps(), false).unwrap();
 
-        let written = m.writer.written().expect("flake.nix should be written");
+        let written = m
+            .flake_writer
+            .written()
+            .expect("flake.nix should be written");
         assert!(written.contains("e607cb5"));
         assert!(written.contains("go_1_21"));
-        assert!(m.repo.persisted_config().is_none());
     }
 
     #[test]

--- a/crates/lnix-app/src/usecase/develop.rs
+++ b/crates/lnix-app/src/usecase/develop.rs
@@ -25,15 +25,12 @@ mod tests {
 
     #[test]
     fn writes_flake_and_enters_shell() {
-        // Arrange
         let m = Mocks::with_config(config_from_yaml(
             "devShell:\n  package:\n    stable:\n      - name: bash\n",
         ));
 
-        // Act
         let code = develop(&m.deps(), false).unwrap();
 
-        // Assert
         assert_eq!(code, 0);
         assert!(m.writer.written().unwrap().contains("bash"));
         assert_eq!(m.nix.develop_calls(), 1);
@@ -51,15 +48,12 @@ mod tests {
 
     #[test]
     fn updates_lock_when_requested() {
-        // Arrange
         let m = Mocks::with_config(config_from_yaml(
             "devShell:\n  package:\n    stable:\n      - name: bash\n",
         ));
 
-        // Act
         let code = develop(&m.deps(), true).unwrap();
 
-        // Assert
         assert_eq!(code, 0);
         assert_eq!(m.nix.flake_update_calls(), 1);
         assert!(
@@ -71,13 +65,10 @@ mod tests {
 
     #[test]
     fn missing_config_short_circuits_before_any_side_effect() {
-        // Arrange
         let m = Mocks::with_missing_config();
 
-        // Act
         let result = develop(&m.deps(), false);
 
-        // Assert
         assert!(matches!(
             result,
             Err(ApplicationError::Config(ConfigError::NotFound(_)))
@@ -88,16 +79,13 @@ mod tests {
 
     #[test]
     fn missing_dotenv_fails_before_writing_flake() {
-        // Arrange
         let m = Mocks::with_config(config_from_yaml(
             "devShell:\n  package:\n    stable:\n      - name: bash\n  env:\n    dotenv:\n      - .env\n",
         ))
         .with_missing_env_files();
 
-        // Act
         let result = develop(&m.deps(), false);
 
-        // Assert
         assert!(matches!(
             result,
             Err(ApplicationError::Config(ConfigError::DotenvFileNotFound(_)))
@@ -106,32 +94,25 @@ mod tests {
     }
 
     #[test]
-    fn resolves_pinned_packages_and_persists_them() {
-        // Arrange
+    fn resolves_pinned_packages_and_renders_them_into_flake() {
         let m = Mocks::with_config(config_from_yaml(
             "devShell:\n  package:\n    stable:\n      - name: bash\n    pinned:\n      - name: go\n        version: \"1.21.13\"\n",
         ));
 
-        // Act
         develop(&m.deps(), false).unwrap();
 
-        // Assert
-        let persisted = m.repo.persisted_config().unwrap();
-        let pinned = &persisted.dev_shell.package.pinned[0];
-        assert_eq!(pinned.resolved_commit.as_deref(), Some("e607cb5"));
-        assert_eq!(pinned.resolved_attr.as_deref(), Some("go_1_21"));
-        assert!(m.writer.written().unwrap().contains("go_1_21"));
+        let written = m.writer.written().expect("flake.nix should be written");
+        assert!(written.contains("e607cb5"));
+        assert!(written.contains("go_1_21"));
+        assert!(m.repo.persisted_config().is_none());
     }
 
     #[test]
     fn warns_about_empty_package_list_via_output_port() {
-        // Arrange
         let m = Mocks::with_config(config_from_yaml("devShell:\n  package:\n    stable: []\n"));
 
-        // Act
         develop(&m.deps(), false).unwrap();
 
-        // Assert
         assert!(
             m.out
                 .warns()

--- a/crates/lnix-app/src/usecase/generate.rs
+++ b/crates/lnix-app/src/usecase/generate.rs
@@ -23,7 +23,7 @@ mod tests {
     use super::*;
     use crate::mocks::*;
     use lnix_domain::ConfigError;
-    use lnix_domain::interface::persistence::PinnedResolutions;
+    use lnix_domain::interface::persistence::{PinnedResolution, PinnedResolutions};
     use std::collections::HashMap;
 
     #[test]
@@ -35,7 +35,10 @@ mod tests {
         let code = generate(&m.deps()).unwrap();
 
         assert_eq!(code, 0);
-        let written = m.writer.written().expect("flake.nix should be written");
+        let written = m
+            .flake_writer
+            .written()
+            .expect("flake.nix should be written");
         assert!(written.contains("bash"));
     }
 
@@ -82,7 +85,7 @@ mod tests {
             result,
             Err(ApplicationError::Config(ConfigError::NotFound(_)))
         ));
-        assert!(m.writer.written().is_none());
+        assert!(m.flake_writer.written().is_none());
     }
 
     #[test]
@@ -93,10 +96,12 @@ mod tests {
 
         generate(&m.deps()).unwrap();
 
-        let written = m.writer.written().expect("flake.nix should be written");
+        let written = m
+            .flake_writer
+            .written()
+            .expect("flake.nix should be written");
         assert!(written.contains("e607cb5"));
         assert!(written.contains("go_1_21"));
-        assert!(m.repo.persisted_config().is_none());
     }
 
     #[test]
@@ -108,8 +113,7 @@ mod tests {
 
         generate(&m.deps()).unwrap();
 
-        assert!(m.repo.persisted_config().is_none());
-        assert!(m.writer.written().is_some());
+        assert!(m.flake_writer.written().is_some());
     }
 
     #[test]
@@ -117,7 +121,10 @@ mod tests {
         let mut cached: PinnedResolutions = HashMap::new();
         cached.insert(
             ("go".parse().unwrap(), "1.21.13".parse().unwrap()),
-            ("CACHED_COMMIT".to_string(), "CACHED_ATTR".to_string()),
+            PinnedResolution {
+                commit: "CACHED_COMMIT".to_string(),
+                attr: "CACHED_ATTR".to_string(),
+            },
         );
         let m = Mocks::with_config(config_from_yaml(
             "devShell:\n  package:\n    stable: []\n    pinned:\n      - name: go\n        version: \"1.21.13\"\n",
@@ -127,7 +134,10 @@ mod tests {
         generate(&m.deps()).unwrap();
 
         assert!(m.resolver.resolve_calls().is_empty());
-        let written = m.writer.written().expect("flake.nix should be written");
+        let written = m
+            .flake_writer
+            .written()
+            .expect("flake.nix should be written");
         assert!(written.contains("CACHED_COMMIT"));
         assert!(written.contains("CACHED_ATTR"));
     }
@@ -145,6 +155,6 @@ mod tests {
             result,
             Err(ApplicationError::Config(ConfigError::DotenvFileNotFound(_)))
         ));
-        assert!(m.writer.written().is_none());
+        assert!(m.flake_writer.written().is_none());
     }
 }

--- a/crates/lnix-app/src/usecase/generate.rs
+++ b/crates/lnix-app/src/usecase/generate.rs
@@ -23,18 +23,17 @@ mod tests {
     use super::*;
     use crate::mocks::*;
     use lnix_domain::ConfigError;
+    use lnix_domain::interface::persistence::PinnedResolutions;
+    use std::collections::HashMap;
 
     #[test]
     fn writes_flake_with_configured_package_and_returns_zero() {
-        // Arrange
         let m = Mocks::with_config(config_from_yaml(
             "devShell:\n  package:\n    stable:\n      - name: bash\n",
         ));
 
-        // Act
         let code = generate(&m.deps()).unwrap();
 
-        // Assert
         assert_eq!(code, 0);
         let written = m.writer.written().expect("flake.nix should be written");
         assert!(written.contains("bash"));
@@ -42,55 +41,43 @@ mod tests {
 
     #[test]
     fn does_not_enter_the_dev_shell() {
-        // Arrange
         let m = Mocks::with_config(config_from_yaml(
             "devShell:\n  package:\n    stable:\n      - name: bash\n",
         ));
 
-        // Act
         generate(&m.deps()).unwrap();
 
-        // Assert
         assert_eq!(m.nix.develop_calls(), 0);
     }
 
     #[test]
     fn does_not_execute_any_ad_hoc_command() {
-        // Arrange
         let m = Mocks::with_config(config_from_yaml(
             "devShell:\n  package:\n    stable:\n      - name: bash\n",
         ));
 
-        // Act
         generate(&m.deps()).unwrap();
 
-        // Assert
         assert!(m.nix.develop_command_args().is_none());
     }
 
     #[test]
     fn does_not_update_the_flake_lock() {
-        // Arrange
         let m = Mocks::with_config(config_from_yaml(
             "devShell:\n  package:\n    stable:\n      - name: bash\n",
         ));
 
-        // Act
         generate(&m.deps()).unwrap();
 
-        // Assert
         assert_eq!(m.nix.flake_update_calls(), 0);
     }
 
     #[test]
     fn missing_config_short_circuits_before_any_side_effect() {
-        // Arrange
         let m = Mocks::with_missing_config();
 
-        // Act
         let result = generate(&m.deps());
 
-        // Assert
         assert!(matches!(
             result,
             Err(ApplicationError::Config(ConfigError::NotFound(_)))
@@ -99,35 +86,61 @@ mod tests {
     }
 
     #[test]
-    fn resolves_pinned_packages_and_persists_them() {
-        // Arrange
+    fn resolves_pinned_packages_and_renders_them_into_flake() {
         let m = Mocks::with_config(config_from_yaml(
             "devShell:\n  package:\n    stable:\n      - name: bash\n    pinned:\n      - name: go\n        version: \"1.21.13\"\n",
         ));
 
-        // Act
         generate(&m.deps()).unwrap();
 
-        // Assert
-        let persisted = m.repo.persisted_config().unwrap();
-        let pinned = &persisted.dev_shell.package.pinned[0];
-        assert_eq!(pinned.resolved_commit.as_deref(), Some("e607cb5"));
-        assert_eq!(pinned.resolved_attr.as_deref(), Some("go_1_21"));
-        assert!(m.writer.written().unwrap().contains("go_1_21"));
+        let written = m.writer.written().expect("flake.nix should be written");
+        assert!(written.contains("e607cb5"));
+        assert!(written.contains("go_1_21"));
+        assert!(m.repo.persisted_config().is_none());
+    }
+
+    #[test]
+    fn generate_does_not_write_back_lazynix_yaml_when_pinned_resolves() {
+        let m = Mocks::with_config(config_from_yaml(
+            "devShell:\n  package:\n    stable: []\n    pinned:\n      - name: go\n        version: \"1.21.13\"\n",
+        ))
+        .with_flake_reader(MockFlakeReader::empty());
+
+        generate(&m.deps()).unwrap();
+
+        assert!(m.repo.persisted_config().is_none());
+        assert!(m.writer.written().is_some());
+    }
+
+    #[test]
+    fn generate_reuses_flake_reader_cache_and_skips_resolver() {
+        let mut cached: PinnedResolutions = HashMap::new();
+        cached.insert(
+            ("go".parse().unwrap(), "1.21.13".parse().unwrap()),
+            ("CACHED_COMMIT".to_string(), "CACHED_ATTR".to_string()),
+        );
+        let m = Mocks::with_config(config_from_yaml(
+            "devShell:\n  package:\n    stable: []\n    pinned:\n      - name: go\n        version: \"1.21.13\"\n",
+        ))
+        .with_flake_reader(MockFlakeReader::new(cached));
+
+        generate(&m.deps()).unwrap();
+
+        assert!(m.resolver.resolve_calls().is_empty());
+        let written = m.writer.written().expect("flake.nix should be written");
+        assert!(written.contains("CACHED_COMMIT"));
+        assert!(written.contains("CACHED_ATTR"));
     }
 
     #[test]
     fn missing_dotenv_fails_before_writing_flake() {
-        // Arrange
         let m = Mocks::with_config(config_from_yaml(
             "devShell:\n  package:\n    stable:\n      - name: bash\n  env:\n    dotenv:\n      - .env\n",
         ))
         .with_missing_env_files();
 
-        // Act
         let result = generate(&m.deps());
 
-        // Assert
         assert!(matches!(
             result,
             Err(ApplicationError::Config(ConfigError::DotenvFileNotFound(_)))

--- a/crates/lnix-app/src/usecase/lint.rs
+++ b/crates/lnix-app/src/usecase/lint.rs
@@ -21,10 +21,9 @@ struct PinnedVerification {
 }
 
 /// Evaluates every declared package (stable + unstable + pinned) via
-/// `nix eval` and, for pinned entries whose commit/attr are not yet
-/// cached, additionally verifies that the requested version can be
-/// resolved. Read-only: never rewrites `lazynix.yaml`.
-/// Exit code 1 when any package fails.
+/// `nix eval` and, for pinned entries, additionally asks the resolver
+/// whether the requested version can still be resolved. Read-only:
+/// never rewrites `lazynix.yaml`. Exit code 1 when any package fails.
 pub fn lint(d: &Deps, verbose: bool, arch: Option<&str>) -> Result<i32, ApplicationError> {
     let config = d.repo.read_config()?;
 
@@ -75,9 +74,9 @@ pub fn lint(d: &Deps, verbose: bool, arch: Option<&str>) -> Result<i32, Applicat
     Ok(if result.errors.is_empty() { 0 } else { 1 })
 }
 
-/// Verifies pinned entries whose commit/attr are not yet cached and
-/// whose attribute name eval has not already failed. Read-only: never
-/// invokes the config writer, so `lazynix.yaml` is left untouched.
+/// Verifies every pinned entry (that survived name eval) by asking the
+/// resolver whether its requested version can be resolved. Read-only:
+/// never invokes the config writer, so `lazynix.yaml` is left untouched.
 ///
 /// Returns [`PinnedVerification`] pairing each failed package name with
 /// its `VersionNotFound` error, so the caller can update the valid list
@@ -92,9 +91,6 @@ fn verify_pinned_versions(
     let mut failed_names = Vec::new();
     let mut errors = Vec::new();
     for entry in pinned {
-        if entry.resolved_commit.is_some() && entry.resolved_attr.is_some() {
-            continue;
-        }
         if name_eval_failed.contains(entry.name.as_str()) {
             continue;
         }
@@ -124,13 +120,10 @@ mod tests {
 
     #[test]
     fn empty_package_list_succeeds_without_evaluating() {
-        // Arrange
         let m = Mocks::with_config(config_from_yaml("devShell:\n  package:\n    stable: []\n"));
 
-        // Act
         let code = lint(&m.deps(), false, None).unwrap();
 
-        // Assert
         assert_eq!(code, 0);
         assert!(
             m.out
@@ -141,15 +134,12 @@ mod tests {
 
     #[test]
     fn all_valid_packages_report_success_with_count() {
-        // Arrange
         let m = Mocks::with_config(config_from_yaml(
             "devShell:\n  package:\n    stable:\n      - name: hello\n    unstable:\n      - name: vim\n",
         ));
 
-        // Act
         let code = lint(&m.deps(), false, None).unwrap();
 
-        // Assert
         assert_eq!(code, 0);
         assert!(
             m.out
@@ -161,16 +151,13 @@ mod tests {
 
     #[test]
     fn failing_package_yields_exit_1_and_categorized_report() {
-        // Arrange
         let m = Mocks::with_config(config_from_yaml(
             "devShell:\n  package:\n    stable:\n      - name: hello\n      - name: ghost-pkg\n",
         ))
         .with_failing_packages(&["ghost-pkg"]);
 
-        // Act
         let code = lint(&m.deps(), false, None).unwrap();
 
-        // Assert
         assert_eq!(code, 1);
         let report = m.out.infos().join("\n");
         assert!(report.contains("PACKAGE_NOT_FOUND"));
@@ -179,15 +166,12 @@ mod tests {
 
     #[test]
     fn pinned_only_config_is_validated_not_skipped() {
-        // Arrange
         let m = Mocks::with_config(config_from_yaml(
             "devShell:\n  package:\n    stable: []\n    pinned:\n      - name: go\n        version: \"1.21.13\"\n",
         ));
 
-        // Act
         let code = lint(&m.deps(), false, None).unwrap();
 
-        // Assert
         assert_eq!(code, 0);
         let infos = m.out.infos();
         assert!(!infos.contains(&"No packages to validate.".to_string()));
@@ -200,16 +184,13 @@ mod tests {
 
     #[test]
     fn pinned_name_that_does_not_exist_reports_categorized_error() {
-        // Arrange
         let m = Mocks::with_config(config_from_yaml(
             "devShell:\n  package:\n    stable: []\n    pinned:\n      - name: ghost-pkg\n        version: \"9.9.9\"\n",
         ))
         .with_failing_packages(&["ghost-pkg"]);
 
-        // Act
         let code = lint(&m.deps(), false, None).unwrap();
 
-        // Assert
         assert_eq!(code, 1);
         let report = m.out.infos().join("\n");
         assert!(report.contains("PACKAGE_NOT_FOUND"));
@@ -218,15 +199,12 @@ mod tests {
 
     #[test]
     fn stable_and_pinned_are_counted_together_on_success() {
-        // Arrange
         let m = Mocks::with_config(config_from_yaml(
             "devShell:\n  package:\n    stable:\n      - name: hello\n    pinned:\n      - name: go\n        version: \"1.21.13\"\n",
         ));
 
-        // Act
         let code = lint(&m.deps(), false, None).unwrap();
 
-        // Assert
         assert_eq!(code, 0);
         let infos = m.out.infos();
         assert!(
@@ -237,46 +215,36 @@ mod tests {
     }
 
     #[test]
-    fn cached_pinned_entry_skips_resolver_call() {
-        // Arrange
+    fn lint_verifies_pinned_even_when_resolved_fields_present() {
         let m = Mocks::with_config(config_from_yaml(
             "devShell:\n  package:\n    stable: []\n    pinned:\n      - name: go\n        version: \"1.21.13\"\n        resolvedCommit: \"e607cb5\"\n        resolvedAttr: \"go_1_21\"\n",
         ));
 
-        // Act
         let code = lint(&m.deps(), false, None).unwrap();
 
-        // Assert
         assert_eq!(code, 0);
-        assert!(m.resolver.resolve_calls().is_empty());
+        assert_eq!(m.resolver.resolve_calls(), vec!["go".to_string()]);
     }
 
     #[test]
     fn lint_never_persists_config_even_after_resolving_versions() {
-        // Arrange
         let m = Mocks::with_config(config_from_yaml(
             "devShell:\n  package:\n    stable: []\n    pinned:\n      - name: go\n        version: \"1.21.13\"\n",
         ));
 
-        // Act
         let _ = lint(&m.deps(), false, None).unwrap();
 
-        // Assert
         assert_eq!(m.resolver.resolve_calls(), vec!["go".to_string()]);
-        assert!(m.repo.persisted_config().is_none());
     }
 
     #[test]
     fn successful_version_resolution_preserves_valid_count_across_stable_and_pinned() {
-        // Arrange
         let m = Mocks::with_config(config_from_yaml(
             "devShell:\n  package:\n    stable:\n      - name: hello\n    pinned:\n      - name: go\n        version: \"1.21.13\"\n",
         ));
 
-        // Act
         let code = lint(&m.deps(), false, None).unwrap();
 
-        // Assert
         assert_eq!(code, 0);
         assert_eq!(m.resolver.resolve_calls(), vec!["go".to_string()]);
         let infos = m.out.infos();
@@ -289,32 +257,26 @@ mod tests {
 
     #[test]
     fn pinned_with_failing_name_eval_skips_resolver_call() {
-        // Arrange
         let m = Mocks::with_config(config_from_yaml(
             "devShell:\n  package:\n    stable: []\n    pinned:\n      - name: ghost-pkg\n        version: \"9.9.9\"\n",
         ))
         .with_failing_packages(&["ghost-pkg"]);
 
-        // Act
         let code = lint(&m.deps(), false, None).unwrap();
 
-        // Assert
         assert_eq!(code, 1);
         assert!(m.resolver.resolve_calls().is_empty());
     }
 
     #[test]
     fn resolver_infra_failure_propagates_as_application_error() {
-        // Arrange
         let m = Mocks::with_config(config_from_yaml(
             "devShell:\n  package:\n    stable: []\n    pinned:\n      - name: go\n        version: \"1.21.13\"\n",
         ))
         .with_resolver_infra_failure();
 
-        // Act
         let result = lint(&m.deps(), false, None);
 
-        // Assert
         assert!(matches!(
             result,
             Err(ApplicationError::Nix(NixError::NoExitCode))
@@ -323,16 +285,13 @@ mod tests {
 
     #[test]
     fn pinned_version_that_cannot_be_resolved_reports_version_not_found() {
-        // Arrange
         let m = Mocks::with_config(config_from_yaml(
             "devShell:\n  package:\n    stable: []\n    pinned:\n      - name: go\n        version: \"9.9.9\"\n",
         ))
         .with_failing_versions(&[("go", "no matching commit")]);
 
-        // Act
         let code = lint(&m.deps(), false, None).unwrap();
 
-        // Assert
         assert_eq!(code, 1);
         let report = m.out.infos().join("\n");
         assert!(report.contains("VERSION_NOT_FOUND"));
@@ -342,16 +301,13 @@ mod tests {
 
     #[test]
     fn verbose_appends_raw_error_details() {
-        // Arrange
         let m = Mocks::with_config(config_from_yaml(
             "devShell:\n  package:\n    stable:\n      - name: ghost-pkg\n",
         ))
         .with_failing_packages(&["ghost-pkg"]);
 
-        // Act
         let code = lint(&m.deps(), true, None).unwrap();
 
-        // Assert
         assert_eq!(code, 1);
         assert!(
             m.out

--- a/crates/lnix-app/src/usecase/run.rs
+++ b/crates/lnix-app/src/usecase/run.rs
@@ -39,17 +39,14 @@ mod tests {
 
     #[test]
     fn regenerates_flake_and_runs_command() {
-        // Arrange
         let m = Mocks::with_config(config_from_yaml(
             "devShell:\n  package:\n    stable:\n      - name: bash\n",
         ));
 
-        // Act
         let code = run(&m.deps(), false, true, vec!["echo".into(), "hi".into()]).unwrap();
 
-        // Assert
         assert_eq!(code, 0);
-        assert!(m.writer.written().is_some());
+        assert!(m.flake_writer.written().is_some());
         assert_eq!(
             m.nix.develop_command_args().unwrap(),
             vec!["echo".to_string(), "hi".to_string()]
@@ -58,15 +55,12 @@ mod tests {
 
     #[test]
     fn no_regen_skips_config_loading_entirely() {
-        // Arrange: no config on disk — --no-regen must not need one
         let m = Mocks::with_missing_config();
 
-        // Act
         let code = run(&m.deps(), false, false, vec!["true".into()]).unwrap();
 
-        // Assert
         assert_eq!(code, 0);
-        assert!(m.writer.written().is_none());
+        assert!(m.flake_writer.written().is_none());
         assert!(
             m.out
                 .infos()
@@ -76,13 +70,10 @@ mod tests {
 
     #[test]
     fn rejects_empty_command() {
-        // Arrange
         let m = Mocks::with_missing_config();
 
-        // Act
         let result = run(&m.deps(), false, true, vec![]);
 
-        // Assert
         assert!(matches!(result, Err(ApplicationError::EmptyRunCommand)));
     }
 }

--- a/crates/lnix-app/src/usecase/test.rs
+++ b/crates/lnix-app/src/usecase/test.rs
@@ -28,33 +28,27 @@ mod tests {
 
     #[test]
     fn runs_declared_tests_after_writing_flake() {
-        // Arrange
         let m = Mocks::with_config(config_from_yaml(
             "devShell:\n  package:\n    stable:\n      - name: bash\n  test:\n    - cargo test\n",
         ));
 
-        // Act
         let code = test(&m.deps(), false).unwrap();
 
-        // Assert
         assert_eq!(code, 0);
-        assert!(m.writer.written().is_some());
+        assert!(m.flake_writer.written().is_some());
         assert_eq!(m.nix.test_calls(), 1);
     }
 
     #[test]
     fn fails_fast_when_no_tests_declared() {
-        // Arrange
         let m = Mocks::with_config(config_from_yaml(
             "devShell:\n  package:\n    stable:\n      - name: bash\n",
         ));
 
-        // Act
         let result = test(&m.deps(), false);
 
-        // Assert
         assert!(matches!(result, Err(ApplicationError::NoTestCommands)));
-        assert!(m.writer.written().is_none());
+        assert!(m.flake_writer.written().is_none());
         assert_eq!(m.nix.test_calls(), 0);
     }
 }

--- a/crates/lnix-domain/src/definition/package.rs
+++ b/crates/lnix-domain/src/definition/package.rs
@@ -30,18 +30,15 @@ pub struct PinnedPackageEntry {
     pub name: PackageName,
     pub version: PackageVersion,
 
-    /// nixpkgs commit hash. Auto-resolved via nix-versions.
-    #[serde(default, skip_serializing_if = "always_skip_serialization")]
+    /// nixpkgs commit hash. Deserialized for backwards compatibility
+    /// only; never serialized because `flake.nix` owns the SSoT.
+    #[serde(default, skip_serializing)]
     pub resolved_commit: Option<String>,
 
-    /// Nix attribute path (e.g., "go_1_21"). Auto-resolved via nix-versions.
-    #[serde(default, skip_serializing_if = "always_skip_serialization")]
+    /// Nix attribute path (e.g., `go_1_21`). Deserialized for
+    /// backwards compatibility only; never serialized.
+    #[serde(default, skip_serializing)]
     pub resolved_attr: Option<String>,
-}
-
-// NOTE: resolved fields never serialize; flake.nix owns the SSoT.
-fn always_skip_serialization<T>(_: &T) -> bool {
-    true
 }
 
 #[cfg(test)]

--- a/crates/lnix-domain/src/definition/package.rs
+++ b/crates/lnix-domain/src/definition/package.rs
@@ -31,12 +31,17 @@ pub struct PinnedPackageEntry {
     pub version: PackageVersion,
 
     /// nixpkgs commit hash. Auto-resolved via nix-versions.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "always_skip_serialization")]
     pub resolved_commit: Option<String>,
 
     /// Nix attribute path (e.g., "go_1_21"). Auto-resolved via nix-versions.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "always_skip_serialization")]
     pub resolved_attr: Option<String>,
+}
+
+// NOTE: resolved fields never serialize; flake.nix owns the SSoT.
+fn always_skip_serialization<T>(_: &T) -> bool {
+    true
 }
 
 #[cfg(test)]
@@ -45,7 +50,6 @@ mod tests {
 
     #[test]
     fn deserializes_pinned_entry_with_resolution() {
-        // Arrange
         let yaml = r#"
 name: go
 version: "1.21.13"
@@ -53,10 +57,8 @@ resolvedCommit: "5ed6275"
 resolvedAttr: "go_1_21"
 "#;
 
-        // Act
         let pinned: PinnedPackageEntry = serde_yaml::from_str(yaml).unwrap();
 
-        // Assert
         assert_eq!(pinned.name.as_str(), "go");
         assert_eq!(pinned.version.as_str(), "1.21.13");
         assert_eq!(pinned.resolved_commit.as_deref(), Some("5ed6275"));
@@ -65,52 +67,129 @@ resolvedAttr: "go_1_21"
 
     #[test]
     fn deserializes_unresolved_pinned_entry() {
-        // Arrange
         let yaml = r#"
 name: go
 version: "1.21.13"
 "#;
 
-        // Act
         let pinned: PinnedPackageEntry = serde_yaml::from_str(yaml).unwrap();
 
-        // Assert
         assert!(pinned.resolved_commit.is_none());
         assert!(pinned.resolved_attr.is_none());
     }
 
     #[test]
     fn rejects_invalid_package_name_at_parse_time() {
-        // Arrange
         let yaml = r#"
 name: "invalid package!"
 version: "1.0"
 "#;
 
-        // Act
         let result = serde_yaml::from_str::<PinnedPackageEntry>(yaml);
 
-        // Assert
         let message = result.unwrap_err().to_string();
         assert!(message.contains("Invalid package name"), "got: {message}");
     }
 
     #[test]
     fn rejects_empty_pinned_version_at_parse_time() {
-        // Arrange
         let yaml = r#"
 name: go
 version: ""
 "#;
 
-        // Act
         let result = serde_yaml::from_str::<PinnedPackageEntry>(yaml);
 
-        // Assert
         let message = result.unwrap_err().to_string();
         assert!(
             message.contains("version cannot be empty"),
             "got: {message}"
         );
+    }
+
+    #[test]
+    fn serialize_omits_resolved_commit() {
+        let pinned = PinnedPackageEntry {
+            name: "go".parse().unwrap(),
+            version: "1.21.13".parse().unwrap(),
+            resolved_commit: Some("5ed6275".to_string()),
+            resolved_attr: None,
+        };
+
+        let yaml = serde_yaml::to_string(&pinned).unwrap();
+
+        assert!(
+            !yaml.contains("resolvedCommit"),
+            "resolvedCommit must not be serialized; got: {yaml}"
+        );
+    }
+
+    #[test]
+    fn serialize_omits_resolved_attr() {
+        let pinned = PinnedPackageEntry {
+            name: "go".parse().unwrap(),
+            version: "1.21.13".parse().unwrap(),
+            resolved_commit: None,
+            resolved_attr: Some("go_1_21".to_string()),
+        };
+
+        let yaml = serde_yaml::to_string(&pinned).unwrap();
+
+        assert!(
+            !yaml.contains("resolvedAttr"),
+            "resolvedAttr must not be serialized; got: {yaml}"
+        );
+    }
+
+    #[test]
+    fn serialize_emits_name_and_version() {
+        let pinned = PinnedPackageEntry {
+            name: "go".parse().unwrap(),
+            version: "1.21.13".parse().unwrap(),
+            resolved_commit: Some("5ed6275".to_string()),
+            resolved_attr: Some("go_1_21".to_string()),
+        };
+
+        let yaml = serde_yaml::to_string(&pinned).unwrap();
+
+        assert!(yaml.contains("name: go"), "missing name; got: {yaml}");
+        assert!(
+            yaml.contains("version: 1.21.13"),
+            "missing version; got: {yaml}"
+        );
+    }
+
+    #[test]
+    fn round_trip_drops_resolved_fields() {
+        let legacy_yaml = r#"
+name: go
+version: "1.21.13"
+resolvedCommit: "5ed6275"
+resolvedAttr: "go_1_21"
+"#;
+
+        let first: PinnedPackageEntry = serde_yaml::from_str(legacy_yaml).unwrap();
+        let re_serialized = serde_yaml::to_string(&first).unwrap();
+        let second: PinnedPackageEntry = serde_yaml::from_str(&re_serialized).unwrap();
+
+        assert!(second.resolved_commit.is_none());
+        assert!(second.resolved_attr.is_none());
+    }
+
+    #[test]
+    fn deserialize_still_accepts_legacy_resolved_fields() {
+        let legacy_yaml = r#"
+name: go
+version: "1.21.13"
+resolvedCommit: "5ed6275"
+resolvedAttr: "go_1_21"
+"#;
+
+        let pinned: PinnedPackageEntry = serde_yaml::from_str(legacy_yaml).unwrap();
+
+        assert_eq!(pinned.name.as_str(), "go");
+        assert_eq!(pinned.version.as_str(), "1.21.13");
+        assert_eq!(pinned.resolved_commit.as_deref(), Some("5ed6275"));
+        assert_eq!(pinned.resolved_attr.as_deref(), Some("go_1_21"));
     }
 }

--- a/crates/lnix-domain/src/error.rs
+++ b/crates/lnix-domain/src/error.rs
@@ -93,6 +93,9 @@ pub enum FlakeError {
     #[error("Failed to write flake.nix: {0}")]
     Write(#[from] std::io::Error),
 
+    /// I/O error while reading `flake.nix`. `#[from]` is attached to
+    /// `Write` because thiserror derives at most one `From<io::Error>`
+    /// per enum, so `Read` variants must be constructed explicitly.
     #[error("Failed to read flake.nix: {0}")]
     Read(std::io::Error),
 }

--- a/crates/lnix-domain/src/error.rs
+++ b/crates/lnix-domain/src/error.rs
@@ -85,12 +85,16 @@ pub enum ConfigError {
     DotenvFileNotFound(String),
 }
 
-/// Failures persisting rendered `flake.nix` content, raised through
-/// [`crate::interface::persistence::FlakeWriter`].
+/// Failures persisting or reading `flake.nix` content, raised through
+/// [`crate::interface::persistence::FlakeWriter`] and
+/// [`crate::interface::persistence::FlakeReader`].
 #[derive(Error, Debug)]
 pub enum FlakeError {
     #[error("Failed to write flake.nix: {0}")]
     Write(#[from] std::io::Error),
+
+    #[error("Failed to read flake.nix: {0}")]
+    Read(std::io::Error),
 }
 
 /// Failures executing `nix`, raised through the gateways in

--- a/crates/lnix-domain/src/interface/persistence/config_repository.rs
+++ b/crates/lnix-domain/src/interface/persistence/config_repository.rs
@@ -1,20 +1,17 @@
-//! Port for reading and writing the project's configuration files.
+//! Port for reading the project's configuration files.
 
 use crate::definition::{DevShellDefinition, Settings};
 use crate::error::ConfigError;
 
-/// Reads and writes `lazynix.yaml` and reads `lazynix-settings.yaml`.
+/// Reads `lazynix.yaml` and `lazynix-settings.yaml`.
 ///
 /// Implementations own the location of these files (the config
-/// directory); callers never handle paths.
+/// directory); callers never handle paths. The port is read-only: the
+/// generated `flake.nix` is the source of truth for resolved pinned
+/// versions, so `lazynix.yaml` is never rewritten.
 pub trait ConfigRepository {
     /// Reads and deserializes `lazynix.yaml`.
     fn read_config(&self) -> Result<DevShellDefinition, ConfigError>;
-
-    /// Serializes `config` back to `lazynix.yaml`.
-    ///
-    /// Used to persist resolved pinned-package versions.
-    fn write_config(&self, config: &DevShellDefinition) -> Result<(), ConfigError>;
 
     /// Reads `lazynix-settings.yaml`, or `None` when the file is absent.
     fn read_settings(&self) -> Result<Option<Settings>, ConfigError>;

--- a/crates/lnix-domain/src/interface/persistence/flake_reader.rs
+++ b/crates/lnix-domain/src/interface/persistence/flake_reader.rs
@@ -1,0 +1,32 @@
+//! Port for reading pinned-package resolutions from an existing `flake.nix`.
+
+use std::collections::HashMap;
+
+use crate::error::FlakeError;
+use crate::values::{PackageName, PackageVersion};
+
+/// The `(commit, attr)` pair a `(name, version)` request resolved to
+/// last time the flake was rendered.
+pub type PinnedResolution = (String, String);
+
+/// Map of pinned-package requests to their recovered resolutions.
+pub type PinnedResolutions = HashMap<(PackageName, PackageVersion), PinnedResolution>;
+
+/// Reads pinned-package resolutions from an existing `flake.nix`.
+///
+/// The `flake.nix` LazyNix generates is the source of truth for the
+/// `(nixpkgs commit, attribute)` pair that a `(name, version)` request
+/// resolved to. Callers use this port to reuse a prior resolution and
+/// avoid re-invoking `nix-versions`.
+///
+/// A missing or malformed file is not an error: the implementation
+/// returns an empty map (or drops the malformed entry) and the caller
+/// falls back to the resolver.
+pub trait FlakeReader {
+    /// Returns a map from `(name, version)` to `(commit, attr)`.
+    ///
+    /// Only entries whose input line and `buildInputs` line are both
+    /// present in the flake are included; partially-recovered entries
+    /// are dropped so the caller re-resolves them from scratch.
+    fn read_pinned_inputs(&self) -> Result<PinnedResolutions, FlakeError>;
+}

--- a/crates/lnix-domain/src/interface/persistence/flake_reader.rs
+++ b/crates/lnix-domain/src/interface/persistence/flake_reader.rs
@@ -5,9 +5,13 @@ use std::collections::HashMap;
 use crate::error::FlakeError;
 use crate::values::{PackageName, PackageVersion};
 
-/// The `(commit, attr)` pair a `(name, version)` request resolved to
-/// last time the flake was rendered.
-pub type PinnedResolution = (String, String);
+/// The nixpkgs commit and attribute path a `(name, version)` request
+/// resolved to last time the flake was rendered.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PinnedResolution {
+    pub commit: String,
+    pub attr: String,
+}
 
 /// Map of pinned-package requests to their recovered resolutions.
 pub type PinnedResolutions = HashMap<(PackageName, PackageVersion), PinnedResolution>;
@@ -17,13 +21,15 @@ pub type PinnedResolutions = HashMap<(PackageName, PackageVersion), PinnedResolu
 /// The `flake.nix` LazyNix generates is the source of truth for the
 /// `(nixpkgs commit, attribute)` pair that a `(name, version)` request
 /// resolved to. Callers use this port to reuse a prior resolution and
-/// avoid re-invoking `nix-versions`.
+/// avoid re-invoking `nix-versions`, which would otherwise require a
+/// subprocess and network I/O and would return non-deterministic
+/// results whenever the underlying channel moves.
 ///
 /// A missing or malformed file is not an error: the implementation
 /// returns an empty map (or drops the malformed entry) and the caller
 /// falls back to the resolver.
 pub trait FlakeReader {
-    /// Returns a map from `(name, version)` to `(commit, attr)`.
+    /// Returns a map from `(name, version)` to its [`PinnedResolution`].
     ///
     /// Only entries whose input line and `buildInputs` line are both
     /// present in the flake are included; partially-recovered entries

--- a/crates/lnix-domain/src/interface/persistence/mod.rs
+++ b/crates/lnix-domain/src/interface/persistence/mod.rs
@@ -3,10 +3,12 @@
 
 mod config_repository;
 mod env_file;
+mod flake_reader;
 mod flake_writer;
 mod scaffolder;
 
 pub use config_repository::ConfigRepository;
 pub use env_file::EnvFilePresenceChecker;
+pub use flake_reader::{FlakeReader, PinnedResolution, PinnedResolutions};
 pub use flake_writer::FlakeWriter;
 pub use scaffolder::ProjectScaffolder;

--- a/crates/lnix-domain/src/lib.rs
+++ b/crates/lnix-domain/src/lib.rs
@@ -26,6 +26,7 @@ pub use definition::{
     TaskDef, validate_config,
 };
 pub use error::{ConfigError, Diagnostic, FlakeError, NixError, ParseError, ValidationError};
+pub use interface::persistence::{FlakeReader, FlakeWriter};
 pub use service::flake::render_flake;
 pub use service::lint::{
     PackageValidationError, ValidationResult, classify_nix_eval_error, format_validation_result,

--- a/crates/lnix-domain/src/service/flake/mod.rs
+++ b/crates/lnix-domain/src/service/flake/mod.rs
@@ -6,7 +6,7 @@
 
 mod build_inputs;
 mod path;
-mod pinned;
+pub mod pinned;
 mod shell_hook;
 mod test_runner;
 
@@ -112,41 +112,32 @@ mod tests {
 
     #[test]
     fn uses_override_stable_url_when_provided() {
-        // Arrange
         let custom_url = "github:NixOS/nixpkgs/nixos-25.06";
 
-        // Act
         let flake = render_from_yaml(BASIC, Some(custom_url));
 
-        // Assert
         assert!(flake.contains(&format!("nixpkgs.url = \"{}\";", custom_url)));
         assert!(!flake.contains("nixpkgs.url = \"github:NixOS/nixpkgs/nixos-25.11\";"));
     }
 
     #[test]
     fn falls_back_to_default_stable_url() {
-        // Arrange / Act
         let flake = render_from_yaml(BASIC, None);
 
-        // Assert
         assert!(flake.contains("nixpkgs.url = \"github:NixOS/nixpkgs/nixos-25.11\";"));
     }
 
     #[test]
     fn propagates_allow_unfree_flag() {
-        // Arrange
         let yaml = "devShell:\n  allowUnfree: false\n  package:\n    stable:\n      - name: bash\n";
 
-        // Act
         let flake = render_from_yaml(yaml, None);
 
-        // Assert
         assert!(flake.contains("config.allowUnfree = false"));
     }
 
     #[test]
     fn renders_pinned_package_end_to_end() {
-        // Arrange
         let yaml = r#"
 devShell:
   package:
@@ -159,10 +150,8 @@ devShell:
         resolvedAttr: "go_1_21"
 "#;
 
-        // Act
         let flake = render_from_yaml(yaml, None);
 
-        // Assert: input, let binding, and buildInputs entry all present
         assert!(flake.contains("nixpkgs--go--1-21-13.url = \"github:NixOS/nixpkgs/e607cb5\";"));
         assert!(flake.contains("pinnedPkgs-go-1-21-13 = import nixpkgs--go--1-21-13"));
         assert!(flake.contains("pinnedPkgs-go-1-21-13.go_1_21"));
@@ -170,7 +159,6 @@ devShell:
 
     #[test]
     fn skips_unresolved_pinned_package() {
-        // Arrange
         let yaml = r#"
 devShell:
   package:
@@ -181,10 +169,8 @@ devShell:
         version: "1.21.13"
 "#;
 
-        // Act
         let flake = render_from_yaml(yaml, None);
 
-        // Assert
         assert!(!flake.contains("nixpkgs--go--1-21-13"));
         assert!(!flake.contains("pinnedPkgs-go"));
     }

--- a/crates/lnix-domain/src/service/flake/pinned.rs
+++ b/crates/lnix-domain/src/service/flake/pinned.rs
@@ -4,8 +4,28 @@
 //! an output parameter, a `let` binding importing that revision, and a
 //! `buildInputs` entry. Only packages whose version has already been
 //! resolved to a commit + attribute are emitted.
+//!
+//! The naming constants below are also imported by the reader adapter
+//! (see `lnix_infra::persistence::flake_reader`); keeping them in one
+//! place prevents silent breakage when the writer format changes.
 
 use crate::{DevShellDefinition, PinnedPackageEntry};
+
+/// Prefix of a flake input name for a pinned package
+/// (`nixpkgs--<name>--<dashed-version>`).
+pub const PINNED_INPUT_PREFIX: &str = "nixpkgs--";
+
+/// Suffix appended to an input name when it becomes a `.url = ...` line
+/// in the flake, including the surrounding space and `=`.
+pub const PINNED_INPUT_URL_SUFFIX: &str = ".url =";
+
+/// Prefix of the `let`-binding / `buildInputs` name for a pinned
+/// package (`pinnedPkgs-<name>-<dashed-version>`).
+pub const PINNED_BINDING_PREFIX: &str = "pinnedPkgs-";
+
+/// Prefix of the resolved `.url` value that points at a specific
+/// nixpkgs commit (`github:NixOS/nixpkgs/<commit>`).
+pub const PINNED_URL_COMMIT_PREFIX: &str = "github:NixOS/nixpkgs/";
 
 fn normalize_version(version: &str) -> String {
     version.replace('.', "-")
@@ -13,7 +33,8 @@ fn normalize_version(version: &str) -> String {
 
 fn input_name(entry: &PinnedPackageEntry) -> String {
     format!(
-        "nixpkgs--{}--{}",
+        "{}{}--{}",
+        PINNED_INPUT_PREFIX,
         entry.name,
         normalize_version(entry.version.as_str())
     )
@@ -21,7 +42,8 @@ fn input_name(entry: &PinnedPackageEntry) -> String {
 
 fn binding_name(entry: &PinnedPackageEntry) -> String {
     format!(
-        "pinnedPkgs-{}-{}",
+        "{}{}-{}",
+        PINNED_BINDING_PREFIX,
         entry.name,
         normalize_version(entry.version.as_str())
     )
@@ -114,29 +136,23 @@ resolvedAttr: "go_1_21"
 
     #[test]
     fn normalizes_dots_to_hyphens() {
-        // Arrange / Act / Assert
         assert_eq!(normalize_version("1.21.13"), "1-21-13");
     }
 
     #[test]
     fn derives_input_and_binding_names() {
-        // Arrange
         let entry = resolved_go();
 
-        // Act / Assert
         assert_eq!(input_name(&entry), "nixpkgs--go--1-21-13");
         assert_eq!(binding_name(&entry), "pinnedPkgs-go-1-21-13");
     }
 
     #[test]
     fn renders_input_pinned_to_commit() {
-        // Arrange
         let entry = resolved_go();
 
-        // Act
         let inputs = render_inputs(&[&entry]);
 
-        // Assert
         assert_eq!(
             inputs,
             "    nixpkgs--go--1-21-13.url = \"github:NixOS/nixpkgs/e607cb5\";"
@@ -145,7 +161,6 @@ resolvedAttr: "go_1_21"
 
     #[test]
     fn output_params_are_empty_without_resolved_entries() {
-        // Arrange / Act / Assert
         assert_eq!(render_output_params(&[]), "");
     }
 }

--- a/crates/lnix-domain/src/values/package_name.rs
+++ b/crates/lnix-domain/src/values/package_name.rs
@@ -11,6 +11,8 @@ use crate::error::ParseError;
 /// - non-empty
 /// - only alphanumerics, `-`, `_`, and `.`
 /// - dots may appear only between segments (no leading/trailing/double dots)
+/// - no consecutive hyphens (`--`); the pinned-input naming scheme
+///   uses `--` as a name/version separator and must stay unambiguous
 ///
 /// The character restriction doubles as a shell-injection guard:
 /// a `PackageName` can be safely embedded in `nix` command arguments.
@@ -25,7 +27,12 @@ impl PackageName {
 }
 
 fn is_valid_package_name(name: &str) -> bool {
-    if name.is_empty() || name.starts_with('.') || name.ends_with('.') || name.contains("..") {
+    if name.is_empty()
+        || name.starts_with('.')
+        || name.ends_with('.')
+        || name.contains("..")
+        || name.contains("--")
+    {
         return false;
     }
     name.chars()
@@ -69,7 +76,6 @@ mod tests {
 
     #[test]
     fn accepts_simple_and_nested_attribute_names() {
-        // Arrange
         let valid_names = [
             "python312",
             "rust-analyzer",
@@ -78,7 +84,6 @@ mod tests {
             "lib.strings.concatStringsSep",
         ];
 
-        // Act & Assert
         for name in valid_names {
             assert!(name.parse::<PackageName>().is_ok(), "should accept {name}");
         }
@@ -86,7 +91,6 @@ mod tests {
 
     #[test]
     fn rejects_invalid_names() {
-        // Arrange
         let invalid_names = [
             "",
             "pkg@version",
@@ -97,7 +101,6 @@ mod tests {
             "pkg..name",
         ];
 
-        // Act & Assert
         for name in invalid_names {
             assert!(
                 name.parse::<PackageName>().is_err(),
@@ -108,11 +111,21 @@ mod tests {
 
     #[test]
     fn rejects_shell_metacharacters() {
-        // Arrange
         let injection_attempts = ["pkg$var", "pkg;cmd", "pkg|cmd", "vim `whoami`"];
 
-        // Act & Assert
         for name in injection_attempts {
+            assert!(
+                name.parse::<PackageName>().is_err(),
+                "should reject {name:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_consecutive_hyphens() {
+        let ambiguous_names = ["foo--bar", "a--b--c", "pkg--"];
+
+        for name in ambiguous_names {
             assert!(
                 name.parse::<PackageName>().is_err(),
                 "should reject {name:?}"

--- a/crates/lnix-infra/src/persistence/config_repository.rs
+++ b/crates/lnix-infra/src/persistence/config_repository.rs
@@ -7,7 +7,7 @@ use lnix_domain::{ConfigError, DevShellDefinition, Settings};
 
 use crate::paths::WorkspacePaths;
 
-/// Reads and writes the config files under [`WorkspacePaths`].
+/// Reads the config files under [`WorkspacePaths`].
 pub struct FsConfigRepository {
     paths: WorkspacePaths,
 }
@@ -28,12 +28,6 @@ impl ConfigRepository for FsConfigRepository {
         }
         let text = fs::read_to_string(&path)?;
         serde_yaml::from_str(&text).map_err(|e| ConfigError::Parse(e.to_string()))
-    }
-
-    fn write_config(&self, config: &DevShellDefinition) -> Result<(), ConfigError> {
-        let text = serde_yaml::to_string(config).map_err(|e| ConfigError::Parse(e.to_string()))?;
-        fs::write(self.paths.config_file(), text)?;
-        Ok(())
     }
 
     fn read_settings(&self) -> Result<Option<Settings>, ConfigError> {
@@ -59,7 +53,6 @@ mod tests {
 
     #[test]
     fn reads_config_from_injected_directory() {
-        // Arrange
         let dir = TempDir::new().unwrap();
         fs::write(
             dir.path().join("lazynix.yaml"),
@@ -67,10 +60,8 @@ mod tests {
         )
         .unwrap();
 
-        // Act
         let config = repository_in(&dir).read_config().unwrap();
 
-        // Assert
         assert_eq!(
             config.dev_shell.package.stable[0].name.as_str(),
             "python312"
@@ -79,64 +70,34 @@ mod tests {
 
     #[test]
     fn reports_missing_config_as_not_found() {
-        // Arrange
         let dir = TempDir::new().unwrap();
 
-        // Act
         let result = repository_in(&dir).read_config();
 
-        // Assert
         assert!(matches!(result, Err(ConfigError::NotFound(_))));
     }
 
     #[test]
     fn reports_invalid_yaml_as_parse_error() {
-        // Arrange
         let dir = TempDir::new().unwrap();
         fs::write(dir.path().join("lazynix.yaml"), ":::not yaml:::").unwrap();
 
-        // Act
         let result = repository_in(&dir).read_config();
 
-        // Assert
         assert!(matches!(result, Err(ConfigError::Parse(_))));
     }
 
     #[test]
-    fn round_trips_config_through_write() {
-        // Arrange
-        let dir = TempDir::new().unwrap();
-        let repository = repository_in(&dir);
-        fs::write(
-            dir.path().join("lazynix.yaml"),
-            "devShell:\n  package:\n    stable:\n      - name: bash\n",
-        )
-        .unwrap();
-        let config = repository.read_config().unwrap();
-
-        // Act
-        repository.write_config(&config).unwrap();
-        let reread = repository.read_config().unwrap();
-
-        // Assert
-        assert_eq!(reread.dev_shell.package.stable[0].name.as_str(), "bash");
-    }
-
-    #[test]
     fn missing_settings_is_none() {
-        // Arrange
         let dir = TempDir::new().unwrap();
 
-        // Act
         let settings = repository_in(&dir).read_settings().unwrap();
 
-        // Assert
         assert!(settings.is_none());
     }
 
     #[test]
     fn reads_settings_when_present() {
-        // Arrange
         let dir = TempDir::new().unwrap();
         fs::write(
             dir.path().join("lazynix-settings.yaml"),
@@ -144,10 +105,8 @@ mod tests {
         )
         .unwrap();
 
-        // Act
         let settings = repository_in(&dir).read_settings().unwrap();
 
-        // Assert
         assert!(settings.unwrap().override_stable_package.is_some());
     }
 }

--- a/crates/lnix-infra/src/persistence/flake_reader.rs
+++ b/crates/lnix-infra/src/persistence/flake_reader.rs
@@ -1,19 +1,21 @@
 //! Filesystem-backed [`FlakeReader`].
+//!
+//! Parses the exact line shapes emitted by `render_flake` in the
+//! domain: the shared naming constants in
+//! `lnix_domain::service::flake::pinned` are the single source of
+//! truth for both writer and reader.
+//!
+//! SEE: crates/lnix-domain/src/service/flake/pinned.rs
 
-use std::collections::HashMap;
-use std::fs;
-use std::io;
+use std::{collections::HashMap, fs};
 
-use lnix_domain::FlakeError;
-use lnix_domain::interface::persistence::{FlakeReader, PinnedResolutions};
-use lnix_domain::{PackageName, PackageVersion};
+use lnix_domain::interface::persistence::{FlakeReader, PinnedResolution, PinnedResolutions};
+use lnix_domain::service::flake::pinned::{
+    PINNED_BINDING_PREFIX, PINNED_INPUT_PREFIX, PINNED_INPUT_URL_SUFFIX, PINNED_URL_COMMIT_PREFIX,
+};
+use lnix_domain::{FlakeError, PackageName, PackageVersion};
 
 use crate::paths::WorkspacePaths;
-
-const URL_PREFIX: &str = "nixpkgs--";
-const URL_MID: &str = ".url";
-const COMMIT_PREFIX: &str = "github:NixOS/nixpkgs/";
-const ATTR_PREFIX: &str = "pinnedPkgs-";
 
 /// Recovers pinned resolutions from the `flake.nix` at
 /// [`WorkspacePaths::flake_file`].
@@ -29,26 +31,26 @@ impl FsFlakeReader {
 
 impl FlakeReader for FsFlakeReader {
     fn read_pinned_inputs(&self) -> Result<PinnedResolutions, FlakeError> {
-        let contents = match fs::read_to_string(self.paths.flake_file()) {
-            Ok(contents) => contents,
-            Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(HashMap::new()),
-            Err(err) => return Err(FlakeError::Read(err)),
+        let Ok(contents) = fs::read_to_string(self.paths.flake_file()) else {
+            return Ok(HashMap::new());
         };
         Ok(parse_pinned_inputs(&contents))
     }
 }
 
 fn parse_pinned_inputs(contents: &str) -> PinnedResolutions {
-    let commits = collect_commits(contents);
-    let mut out = HashMap::new();
+    let mut commits = collect_commits(contents);
+    let mut resolutions = HashMap::new();
     for line in contents.lines() {
         let Some((key, attr)) = parse_attr_line(line, &commits) else {
             continue;
         };
-        let commit = commits[&key].clone();
-        out.insert(key, (commit, attr));
+        let commit = commits
+            .remove(&key)
+            .expect("commit present by construction");
+        resolutions.insert(key, PinnedResolution { commit, attr });
     }
-    out
+    resolutions
 }
 
 fn collect_commits(contents: &str) -> HashMap<(PackageName, PackageVersion), String> {
@@ -62,11 +64,12 @@ fn collect_commits(contents: &str) -> HashMap<(PackageName, PackageVersion), Str
 }
 
 fn parse_url_line(line: &str) -> Option<((PackageName, PackageVersion), String)> {
-    let rest = line.trim_start().strip_prefix(URL_PREFIX)?;
-    let (name_and_version, tail) = rest.split_once(URL_MID)?;
-    let (name_str, dashed_version) = name_and_version.split_once("--")?;
-    let url = extract_quoted_url(tail)?;
-    let commit = url.strip_prefix(COMMIT_PREFIX)?;
+    let after_input_prefix = line.trim_start().strip_prefix(PINNED_INPUT_PREFIX)?;
+    let (name_and_version, after_dot_url) =
+        after_input_prefix.split_once(PINNED_INPUT_URL_SUFFIX)?;
+    let (name_str, dashed_version) = split_name_and_version(name_and_version)?;
+    let quoted_value = extract_quoted_url(after_dot_url)?;
+    let commit = quoted_value.strip_prefix(PINNED_URL_COMMIT_PREFIX)?;
     if commit.is_empty() {
         return None;
     }
@@ -74,39 +77,49 @@ fn parse_url_line(line: &str) -> Option<((PackageName, PackageVersion), String)>
     Some((key, commit.to_string()))
 }
 
-fn extract_quoted_url(tail: &str) -> Option<&str> {
-    let after_eq = tail.trim_start().strip_prefix('=')?.trim_start();
-    let inside = after_eq.strip_prefix('"')?;
-    let (url, _) = inside.split_once('"')?;
+fn extract_quoted_url(after_dot_url: &str) -> Option<&str> {
+    let after_equals = after_dot_url.trim_start();
+    let quoted_value = after_equals.strip_prefix('"')?;
+    let (url, _) = quoted_value.split_once('"')?;
     Some(url)
 }
 
 fn parse_attr_line(
     line: &str,
-    known: &HashMap<(PackageName, PackageVersion), String>,
+    commits: &HashMap<(PackageName, PackageVersion), String>,
 ) -> Option<((PackageName, PackageVersion), String)> {
     let trimmed = line.trim();
-    let rest = trimmed.strip_prefix(ATTR_PREFIX)?;
+    let rest = trimmed.strip_prefix(PINNED_BINDING_PREFIX)?;
     let (name_and_version, attr_tail) = rest.split_once('.')?;
-    let key = match_known_key(name_and_version, known)?;
-    let attr = attr_tail.trim_end_matches(|c: char| c == ',' || c.is_whitespace());
+    let key = match_known_key(name_and_version, commits)?;
+    let attr: String = attr_tail
+        .chars()
+        .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+        .collect();
     if attr.is_empty() {
         return None;
     }
-    Some((key, attr.to_string()))
+    Some((key, attr))
 }
 
 fn match_known_key(
     name_and_version: &str,
-    known: &HashMap<(PackageName, PackageVersion), String>,
+    commits: &HashMap<(PackageName, PackageVersion), String>,
 ) -> Option<(PackageName, PackageVersion)> {
-    for (name, version) in known.keys() {
+    for (name, version) in commits.keys() {
         let expected = format!("{}-{}", name.as_str(), version.as_str().replace('.', "-"));
         if expected == name_and_version {
             return Some((name.clone(), version.clone()));
         }
     }
     None
+}
+
+/// Splits `name-and-dashed-version` at the `--` separator emitted by
+/// the writer. Callers rely on `PackageName` rejecting names that
+/// themselves contain `--` so this split is unambiguous.
+fn split_name_and_version(name_and_version: &str) -> Option<(&str, &str)> {
+    name_and_version.split_once("--")
 }
 
 fn build_key(name_str: &str, dashed_version: &str) -> Option<(PackageName, PackageVersion)> {
@@ -134,6 +147,13 @@ mod tests {
 
     fn key(name: &str, version: &str) -> (PackageName, PackageVersion) {
         (name.parse().unwrap(), version.parse().unwrap())
+    }
+
+    fn resolution(commit: &str, attr: &str) -> PinnedResolution {
+        PinnedResolution {
+            commit: commit.into(),
+            attr: attr.into(),
+        }
     }
 
     const SINGLE_GO_FLAKE: &str = r#"{
@@ -185,10 +205,7 @@ mod tests {
         let inputs = reader_for(&dir).read_pinned_inputs().unwrap();
 
         let mut expected = HashMap::new();
-        expected.insert(
-            key("go", "1.21.13"),
-            ("5ed6275".to_string(), "go_1_21".to_string()),
-        );
+        expected.insert(key("go", "1.21.13"), resolution("5ed6275", "go_1_21"));
         assert_eq!(inputs, expected);
     }
 
@@ -217,10 +234,7 @@ mod tests {
         let inputs = reader_for(&dir).read_pinned_inputs().unwrap();
 
         let mut expected = HashMap::new();
-        expected.insert(
-            key("go", "1.21.13"),
-            ("5ed6275".to_string(), "go_1_21".to_string()),
-        );
+        expected.insert(key("go", "1.21.13"), resolution("5ed6275", "go_1_21"));
         assert_eq!(inputs, expected);
     }
 
@@ -306,6 +320,16 @@ mod tests {
     }
 
     #[test]
+    fn returns_empty_map_when_read_fails() {
+        let dir = TempDir::new().unwrap();
+        fs::create_dir(dir.path().join("flake.nix")).unwrap();
+
+        let inputs = reader_for(&dir).read_pinned_inputs().unwrap();
+
+        assert!(inputs.is_empty());
+    }
+
+    #[test]
     fn reads_multiple_pinned_entries() {
         let dir = TempDir::new().unwrap();
         write_flake(&dir, TWO_PINNED_FLAKE);
@@ -313,14 +337,70 @@ mod tests {
         let inputs = reader_for(&dir).read_pinned_inputs().unwrap();
 
         let mut expected = HashMap::new();
-        expected.insert(
-            key("go", "1.21.13"),
-            ("5ed6275".to_string(), "go_1_21".to_string()),
+        expected.insert(key("go", "1.21.13"), resolution("5ed6275", "go_1_21"));
+        expected.insert(key("rust", "1.70.0"), resolution("abcd123", "rustc"));
+        assert_eq!(inputs, expected);
+    }
+
+    #[test]
+    fn does_not_confuse_name_containing_dot_url_prefix() {
+        let dir = TempDir::new().unwrap();
+        write_flake(
+            &dir,
+            r#"{
+  inputs = {
+    nixpkgs--urlHelper--1-0-0.url = "github:NixOS/nixpkgs/deadbee";
+  };
+  outputs = { self, ... }:
+    let
+      pinnedPkgs-urlHelper-1-0-0 = import nixpkgs--urlHelper--1-0-0 { };
+    in
+    {
+      devShells.default = stablePackages.mkShell {
+        buildInputs = [
+          pinnedPkgs-urlHelper-1-0-0.urlHelper
+        ];
+      };
+    };
+}
+"#,
         );
+
+        let inputs = reader_for(&dir).read_pinned_inputs().unwrap();
+
+        let mut expected = HashMap::new();
         expected.insert(
-            key("rust", "1.70.0"),
-            ("abcd123".to_string(), "rustc".to_string()),
+            key("urlHelper", "1.0.0"),
+            resolution("deadbee", "urlHelper"),
         );
+        assert_eq!(inputs, expected);
+    }
+
+    #[test]
+    fn attr_trailing_semicolon_is_stripped() {
+        let dir = TempDir::new().unwrap();
+        write_flake(
+            &dir,
+            r#"{
+  inputs = {
+    nixpkgs--go--1-21-13.url = "github:NixOS/nixpkgs/5ed6275";
+  };
+  outputs = { self, ... }:
+    {
+      devShells.default = stablePackages.mkShell {
+        buildInputs = [
+          pinnedPkgs-go-1-21-13.go_1_21;
+        ];
+      };
+    };
+}
+"#,
+        );
+
+        let inputs = reader_for(&dir).read_pinned_inputs().unwrap();
+
+        let mut expected = HashMap::new();
+        expected.insert(key("go", "1.21.13"), resolution("5ed6275", "go_1_21"));
         assert_eq!(inputs, expected);
     }
 }

--- a/crates/lnix-infra/src/persistence/flake_reader.rs
+++ b/crates/lnix-infra/src/persistence/flake_reader.rs
@@ -1,0 +1,326 @@
+//! Filesystem-backed [`FlakeReader`].
+
+use std::collections::HashMap;
+use std::fs;
+use std::io;
+
+use lnix_domain::FlakeError;
+use lnix_domain::interface::persistence::{FlakeReader, PinnedResolutions};
+use lnix_domain::{PackageName, PackageVersion};
+
+use crate::paths::WorkspacePaths;
+
+const URL_PREFIX: &str = "nixpkgs--";
+const URL_MID: &str = ".url";
+const COMMIT_PREFIX: &str = "github:NixOS/nixpkgs/";
+const ATTR_PREFIX: &str = "pinnedPkgs-";
+
+/// Recovers pinned resolutions from the `flake.nix` at
+/// [`WorkspacePaths::flake_file`].
+pub struct FsFlakeReader {
+    paths: WorkspacePaths,
+}
+
+impl FsFlakeReader {
+    pub fn new(paths: WorkspacePaths) -> Self {
+        Self { paths }
+    }
+}
+
+impl FlakeReader for FsFlakeReader {
+    fn read_pinned_inputs(&self) -> Result<PinnedResolutions, FlakeError> {
+        let contents = match fs::read_to_string(self.paths.flake_file()) {
+            Ok(contents) => contents,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(HashMap::new()),
+            Err(err) => return Err(FlakeError::Read(err)),
+        };
+        Ok(parse_pinned_inputs(&contents))
+    }
+}
+
+fn parse_pinned_inputs(contents: &str) -> PinnedResolutions {
+    let commits = collect_commits(contents);
+    let mut out = HashMap::new();
+    for line in contents.lines() {
+        let Some((key, attr)) = parse_attr_line(line, &commits) else {
+            continue;
+        };
+        let commit = commits[&key].clone();
+        out.insert(key, (commit, attr));
+    }
+    out
+}
+
+fn collect_commits(contents: &str) -> HashMap<(PackageName, PackageVersion), String> {
+    let mut commits = HashMap::new();
+    for line in contents.lines() {
+        if let Some((key, commit)) = parse_url_line(line) {
+            commits.insert(key, commit);
+        }
+    }
+    commits
+}
+
+fn parse_url_line(line: &str) -> Option<((PackageName, PackageVersion), String)> {
+    let rest = line.trim_start().strip_prefix(URL_PREFIX)?;
+    let (name_and_version, tail) = rest.split_once(URL_MID)?;
+    let (name_str, dashed_version) = name_and_version.split_once("--")?;
+    let url = extract_quoted_url(tail)?;
+    let commit = url.strip_prefix(COMMIT_PREFIX)?;
+    if commit.is_empty() {
+        return None;
+    }
+    let key = build_key(name_str, dashed_version)?;
+    Some((key, commit.to_string()))
+}
+
+fn extract_quoted_url(tail: &str) -> Option<&str> {
+    let after_eq = tail.trim_start().strip_prefix('=')?.trim_start();
+    let inside = after_eq.strip_prefix('"')?;
+    let (url, _) = inside.split_once('"')?;
+    Some(url)
+}
+
+fn parse_attr_line(
+    line: &str,
+    known: &HashMap<(PackageName, PackageVersion), String>,
+) -> Option<((PackageName, PackageVersion), String)> {
+    let trimmed = line.trim();
+    let rest = trimmed.strip_prefix(ATTR_PREFIX)?;
+    let (name_and_version, attr_tail) = rest.split_once('.')?;
+    let key = match_known_key(name_and_version, known)?;
+    let attr = attr_tail.trim_end_matches(|c: char| c == ',' || c.is_whitespace());
+    if attr.is_empty() {
+        return None;
+    }
+    Some((key, attr.to_string()))
+}
+
+fn match_known_key(
+    name_and_version: &str,
+    known: &HashMap<(PackageName, PackageVersion), String>,
+) -> Option<(PackageName, PackageVersion)> {
+    for (name, version) in known.keys() {
+        let expected = format!("{}-{}", name.as_str(), version.as_str().replace('.', "-"));
+        if expected == name_and_version {
+            return Some((name.clone(), version.clone()));
+        }
+    }
+    None
+}
+
+fn build_key(name_str: &str, dashed_version: &str) -> Option<(PackageName, PackageVersion)> {
+    let name = name_str.parse::<PackageName>().ok()?;
+    let version = dashed_version
+        .replace('-', ".")
+        .parse::<PackageVersion>()
+        .ok()?;
+    Some((name, version))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write_flake(dir: &TempDir, contents: &str) {
+        fs::write(dir.path().join("flake.nix"), contents).unwrap();
+    }
+
+    fn reader_for(dir: &TempDir) -> FsFlakeReader {
+        FsFlakeReader::new(WorkspacePaths::new(dir.path()))
+    }
+
+    fn key(name: &str, version: &str) -> (PackageName, PackageVersion) {
+        (name.parse().unwrap(), version.parse().unwrap())
+    }
+
+    const SINGLE_GO_FLAKE: &str = r#"{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs--go--1-21-13.url = "github:NixOS/nixpkgs/5ed6275";
+  };
+  outputs = { self, nixpkgs, nixpkgs--go--1-21-13, ... }:
+    let
+      pinnedPkgs-go-1-21-13 = import nixpkgs--go--1-21-13 { };
+    in
+    {
+      devShells.default = stablePackages.mkShell {
+        buildInputs = [
+          pinnedPkgs-go-1-21-13.go_1_21
+        ];
+      };
+    };
+}
+"#;
+
+    const TWO_PINNED_FLAKE: &str = r#"{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs--go--1-21-13.url = "github:NixOS/nixpkgs/5ed6275";
+    nixpkgs--rust--1-70-0.url = "github:NixOS/nixpkgs/abcd123";
+  };
+  outputs = { self, nixpkgs, nixpkgs--go--1-21-13, nixpkgs--rust--1-70-0, ... }:
+    let
+      pinnedPkgs-go-1-21-13 = import nixpkgs--go--1-21-13 { };
+      pinnedPkgs-rust-1-70-0 = import nixpkgs--rust--1-70-0 { };
+    in
+    {
+      devShells.default = stablePackages.mkShell {
+        buildInputs = [
+          pinnedPkgs-go-1-21-13.go_1_21
+          pinnedPkgs-rust-1-70-0.rustc
+        ];
+      };
+    };
+}
+"#;
+
+    #[test]
+    fn reads_single_pinned_entry() {
+        let dir = TempDir::new().unwrap();
+        write_flake(&dir, SINGLE_GO_FLAKE);
+
+        let inputs = reader_for(&dir).read_pinned_inputs().unwrap();
+
+        let mut expected = HashMap::new();
+        expected.insert(
+            key("go", "1.21.13"),
+            ("5ed6275".to_string(), "go_1_21".to_string()),
+        );
+        assert_eq!(inputs, expected);
+    }
+
+    #[test]
+    fn skips_malformed_url_and_keeps_valid_entry() {
+        let dir = TempDir::new().unwrap();
+        write_flake(
+            &dir,
+            r#"{
+  inputs = {
+    nixpkgs--broken--0-0-0.url = "invalid";
+    nixpkgs--go--1-21-13.url = "github:NixOS/nixpkgs/5ed6275";
+  };
+  outputs = {
+    devShells.default = stablePackages.mkShell {
+      buildInputs = [
+        pinnedPkgs-broken-0-0-0.some_attr
+        pinnedPkgs-go-1-21-13.go_1_21
+      ];
+    };
+  };
+}
+"#,
+        );
+
+        let inputs = reader_for(&dir).read_pinned_inputs().unwrap();
+
+        let mut expected = HashMap::new();
+        expected.insert(
+            key("go", "1.21.13"),
+            ("5ed6275".to_string(), "go_1_21".to_string()),
+        );
+        assert_eq!(inputs, expected);
+    }
+
+    #[test]
+    fn returns_empty_map_for_flake_without_pinned_section() {
+        let dir = TempDir::new().unwrap();
+        write_flake(
+            &dir,
+            r#"{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+  outputs = { self, nixpkgs, nixpkgs-unstable, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        stablePackages = import nixpkgs { inherit system; };
+      in
+      {
+        devShells.default = stablePackages.mkShell {
+          buildInputs = [
+            stablePackages.bash
+          ];
+        };
+      });
+}
+"#,
+        );
+
+        let inputs = reader_for(&dir).read_pinned_inputs().unwrap();
+
+        assert!(inputs.is_empty());
+    }
+
+    #[test]
+    fn drops_entry_when_only_url_line_present() {
+        let dir = TempDir::new().unwrap();
+        write_flake(
+            &dir,
+            r#"{
+  inputs = {
+    nixpkgs--go--1-21-13.url = "github:NixOS/nixpkgs/5ed6275";
+  };
+}
+"#,
+        );
+
+        let inputs = reader_for(&dir).read_pinned_inputs().unwrap();
+
+        assert!(inputs.is_empty());
+    }
+
+    #[test]
+    fn drops_entry_when_only_attr_line_present() {
+        let dir = TempDir::new().unwrap();
+        write_flake(
+            &dir,
+            r#"{
+  outputs = {
+    devShells.default = stablePackages.mkShell {
+      buildInputs = [
+        pinnedPkgs-go-1-21-13.go_1_21
+      ];
+    };
+  };
+}
+"#,
+        );
+
+        let inputs = reader_for(&dir).read_pinned_inputs().unwrap();
+
+        assert!(inputs.is_empty());
+    }
+
+    #[test]
+    fn returns_empty_map_when_flake_missing() {
+        let dir = TempDir::new().unwrap();
+
+        let inputs = reader_for(&dir).read_pinned_inputs().unwrap();
+
+        assert!(inputs.is_empty());
+    }
+
+    #[test]
+    fn reads_multiple_pinned_entries() {
+        let dir = TempDir::new().unwrap();
+        write_flake(&dir, TWO_PINNED_FLAKE);
+
+        let inputs = reader_for(&dir).read_pinned_inputs().unwrap();
+
+        let mut expected = HashMap::new();
+        expected.insert(
+            key("go", "1.21.13"),
+            ("5ed6275".to_string(), "go_1_21".to_string()),
+        );
+        expected.insert(
+            key("rust", "1.70.0"),
+            ("abcd123".to_string(), "rustc".to_string()),
+        );
+        assert_eq!(inputs, expected);
+    }
+}

--- a/crates/lnix-infra/src/persistence/mod.rs
+++ b/crates/lnix-infra/src/persistence/mod.rs
@@ -2,10 +2,12 @@
 
 mod config_repository;
 mod env_checker;
+mod flake_reader;
 mod flake_writer;
 mod scaffolder;
 
 pub use config_repository::FsConfigRepository;
 pub use env_checker::FsEnvFileChecker;
+pub use flake_reader::FsFlakeReader;
 pub use flake_writer::FsFlakeWriter;
 pub use scaffolder::FsProjectScaffolder;

--- a/crates/lnix-infra/templates/lazynix.yaml.template
+++ b/crates/lnix-infra/templates/lazynix.yaml.template
@@ -7,8 +7,8 @@ devShell:
     # Optional: Pin a package to a specific version (resolved via nix-versions).
     # Each entry needs `name` and `version`, NOT a single string like `cowsay_3.0.0`.
     # Find available versions with: lnix search <name>
-    # After the first `lnix develop`, resolvedCommit / resolvedAttr are filled
-    # in automatically and written back to this file.
+    # The resolved nixpkgs commit is embedded in the generated flake.nix,
+    # so subsequent runs skip the nix-versions call. This file stays untouched.
     # To use: replace `pinned: []` below with the commented entries (remove the # marks)
     pinned: []
     #   - name: go

--- a/crates/lnix-infra/tests/yaml_template_test.rs
+++ b/crates/lnix-infra/tests/yaml_template_test.rs
@@ -36,3 +36,23 @@ fn yaml_template_documents_pinned_usage() {
     assert_eq!(entries[0].name.as_str(), "go");
     assert_eq!(entries[0].version.as_str(), "1.21.13");
 }
+
+#[test]
+fn yaml_template_describes_flake_embedding_not_write_back() {
+    assert!(
+        YAML_TEMPLATE.contains("embedded in the generated flake.nix"),
+        "template should explain that the pinned commit is embedded in flake.nix"
+    );
+    assert!(
+        !YAML_TEMPLATE.contains("written back"),
+        "template must not promise write-back to lazynix.yaml"
+    );
+    assert!(
+        !YAML_TEMPLATE.contains("resolvedCommit"),
+        "template must not surface resolvedCommit as user-facing state"
+    );
+    assert!(
+        !YAML_TEMPLATE.contains("resolvedAttr"),
+        "template must not surface resolvedAttr as user-facing state"
+    );
+}

--- a/crates/lnix/src/composition.rs
+++ b/crates/lnix/src/composition.rs
@@ -11,13 +11,14 @@ use lnix_infra::WorkspacePaths;
 use lnix_infra::gateway::{NixVersionsResolver, SubprocessNixEvaluator, SubprocessNixRunner};
 use lnix_infra::output::TerminalOutput;
 use lnix_infra::persistence::{
-    FsConfigRepository, FsEnvFileChecker, FsFlakeWriter, FsProjectScaffolder,
+    FsConfigRepository, FsEnvFileChecker, FsFlakeReader, FsFlakeWriter, FsProjectScaffolder,
 };
 
 /// Owns one adapter per port for the duration of a command.
 pub struct AdapterSet {
     repo: FsConfigRepository,
     writer: FsFlakeWriter,
+    flake_reader: FsFlakeReader,
     env: FsEnvFileChecker,
     scaffolder: FsProjectScaffolder,
     nix: SubprocessNixRunner,
@@ -32,6 +33,7 @@ impl AdapterSet {
         Self {
             repo: FsConfigRepository::new(paths.clone()),
             writer: FsFlakeWriter::new(paths.clone()),
+            flake_reader: FsFlakeReader::new(paths.clone()),
             env: FsEnvFileChecker::new(paths.clone()),
             scaffolder: FsProjectScaffolder::new(paths),
             nix: SubprocessNixRunner,
@@ -45,6 +47,7 @@ impl AdapterSet {
         Deps {
             repo: &self.repo,
             writer: &self.writer,
+            flake_reader: &self.flake_reader,
             env: &self.env,
             scaffolder: &self.scaffolder,
             nix: &self.nix,

--- a/crates/lnix/src/composition.rs
+++ b/crates/lnix/src/composition.rs
@@ -17,7 +17,7 @@ use lnix_infra::persistence::{
 /// Owns one adapter per port for the duration of a command.
 pub struct AdapterSet {
     repo: FsConfigRepository,
-    writer: FsFlakeWriter,
+    flake_writer: FsFlakeWriter,
     flake_reader: FsFlakeReader,
     env: FsEnvFileChecker,
     scaffolder: FsProjectScaffolder,
@@ -32,7 +32,7 @@ impl AdapterSet {
         let paths = WorkspacePaths::new(config_dir);
         Self {
             repo: FsConfigRepository::new(paths.clone()),
-            writer: FsFlakeWriter::new(paths.clone()),
+            flake_writer: FsFlakeWriter::new(paths.clone()),
             flake_reader: FsFlakeReader::new(paths.clone()),
             env: FsEnvFileChecker::new(paths.clone()),
             scaffolder: FsProjectScaffolder::new(paths),
@@ -46,7 +46,7 @@ impl AdapterSet {
     pub fn deps(&self) -> Deps<'_> {
         Deps {
             repo: &self.repo,
-            writer: &self.writer,
+            flake_writer: &self.flake_writer,
             flake_reader: &self.flake_reader,
             env: &self.env,
             scaffolder: &self.scaffolder,

--- a/document/en/getting_started.md
+++ b/document/en/getting_started.md
@@ -245,21 +245,11 @@ devShell:
         version: "1.21.13"
 ```
 
-3. Run `lnix develop`. LazyNix invokes `nix-versions` to look up the nixpkgs commit hash and Nix attribute path for that version, and the resolved metadata is written back to `lazynix.yaml` as `resolvedCommit` and `resolvedAttr`:
+3. Run `lnix develop`. LazyNix invokes `nix-versions` to look up the nixpkgs commit hash and Nix attribute path for that version, then embeds the resolved commit into the generated `flake.nix` as its input URL. Subsequent runs read that `flake.nix` directly, so `nix-versions` is called at most once per (name, version) pair. `lazynix.yaml` itself stays untouched — the `flake.nix` **is** the cache.
 
-```yaml
-devShell:
-  package:
-    pinned:
-      - name: go
-        version: "1.21.13"
-        resolvedCommit: "5ed6275"
-        resolvedAttr: "go_1_21"
-```
+Every developer on your team gets exactly Go 1.21.13, without any drift or repeated network lookups.
 
-Once resolved, subsequent runs reuse the cached resolution — no repeated network lookups, no drift. Every developer on your team gets exactly Go 1.21.13.
-
-> **Note:** `lnix lint` validates `stable`, `unstable`, **and** `pinned` packages. For `pinned` entries whose `resolvedCommit` / `resolvedAttr` are not yet cached in `lazynix.yaml`, `lint` additionally asks `nix-versions` whether the requested version can still be resolved — so a typo in the version constraint is caught before the next `lnix develop`.
+> **Note:** `lnix lint` validates `stable`, `unstable`, **and** `pinned` packages. For each `pinned` entry, `lint` additionally asks `nix-versions` whether the requested version can still be resolved — so a typo in the version constraint is caught before the next `lnix develop`.
 
 ## Searching for Available Versions
 
@@ -329,7 +319,7 @@ In this guide, you have:
 - Entered the environment with `lnix develop`
 - Run commands with `lnix run` and defined reusable tasks
 - Validated your configuration with `lnix lint`
-- Pinned an individual package to a specific version with `devShell.package.pinned`, letting LazyNix populate `resolvedCommit` and `resolvedAttr`
+- Pinned an individual package to a specific version with `devShell.package.pinned`, letting LazyNix embed the resolved nixpkgs commit into the generated `flake.nix`
 - Discovered available versions with `lnix search`
 - Refreshed `flake.lock` in isolation with `lnix update`
 - Loaded shell aliases from external files with `devShell.shellAlias`

--- a/document/en/system_architecture.md
+++ b/document/en/system_architecture.md
@@ -115,7 +115,7 @@ DevShellDefinition
 
 Notes on the newer fields:
 
-- `pinned` binds a package to an exact version. `resolvedCommit` and `resolvedAttr` are filled in the first time the pipeline resolves the version through `VersionResolver`, and are then written back to `lazynix.yaml` so subsequent runs skip the lookup.
+- `pinned` binds a package to an exact version. The pipeline resolves the version through `VersionResolver` once and embeds the resulting `(commit, attr)` pair into the generated `flake.nix`; that flake is the source of truth for the resolution. `lazynix.yaml` is never mutated. Subsequent runs read the pair back from `flake.nix` via the `FlakeReader` port. Legacy `resolvedCommit` / `resolvedAttr` fields still deserialize for backwards compatibility but are never serialized.
 - `shellAlias` lists files whose shell alias definitions are loaded into the dev shell.
 - `env.envvar[].name` is an `EnvVarName` and `task` keys are `TaskName`, so invalid identifiers are rejected at YAML parse time.
 
@@ -152,8 +152,9 @@ User runs: lnix develop [--update]
        ├── ConfigRepository::read_config           (lazynix.yaml → DevShellDefinition)
        ├── lnix_domain::validate_config            (diagnostics → OutputPort::warn)
        ├── validate_env_files                      (dotenv files must exist)
-       └── resolve_pinned_packages                 (VersionResolver::resolve →
-                                                    write back to lazynix.yaml)
+       └── resolve_pinned_packages                 (FlakeReader::read_pinned_inputs
+                                                    hits, else VersionResolver::resolve;
+                                                    lazynix.yaml is never mutated)
   │
   4. lnix_app::pipeline::write_flake
        └── lnix_domain::render_flake → FlakeWriter::write_flake

--- a/document/jp/design/version-pinning.md
+++ b/document/jp/design/version-pinning.md
@@ -1,5 +1,14 @@
 # Design: Version Pinning (Issue #14)
 
+> **注記 (v0.4 以降)**: 以下は v1.0.0 当時 (廃止) の仕様である。
+> v0.4 以降、pinned の解決結果は生成される `flake.nix` に埋め込まれ、
+> それが真実の情報源 (SSoT) となる。`lazynix.yaml` への書き戻しは行わない。
+> 再実行時は `FlakeReader` ポートが `flake.nix` から `(commit, attr)` を
+> 復元し、キャッシュヒット時は resolver 呼び出しをスキップする。
+> pre-release 表記 (`1.0.0-rc1` など) の version は flake input 名の区切り
+> `-` と衝突するため cache 対象外 (毎回 resolver を呼ぶ)。
+> 詳細な本文は歴史的記録として残置している。
+
 ## Goal
 
 LazyNix で個々のパッケージのバージョンを指定できるようにする。
@@ -15,7 +24,7 @@ nix-versions をラップし、バージョン検索と flake.nix への統合�
 | 4 | flake input 命名 | `nixpkgs--<package>--<version>` |
 | 5 | 検索 CLI | `lnix search <pkg> --version "<constraint>"` |
 | 6 | version の値 | 完全一致のみ |
-| 7 | 解決済みコミット保持 | lazynix.yaml に `resolvedCommit`, `resolvedAttr` を自動追記 |
+| 7 | 解決済みコミット保持 | lazynix.yaml に `resolvedCommit`, `resolvedAttr` を自動追記 (※v0.4 以降廃止 — 現行は flake.nix が SSoT) |
 | 8 | パッケージ配置 | stable / unstable / pinned の3セクション |
 
 ---
@@ -173,7 +182,7 @@ pub struct PinnedPackageEntry {
 4. nix-versions を呼び出して解決:
    $ nix run github:vic/nix-versions -- --json --one '<name>@<version>'
    → { "installable": "nixpkgs/<commit>#<attr>" }
-5. resolvedCommit と resolvedAttr を lazynix.yaml に書き戻す
+5. resolvedCommit と resolvedAttr を lazynix.yaml に書き戻す (※v0.4 以降廃止 — flake.nix に埋め込む)
 6. flake.nix を生成 (pinned inputs を含む)
 7. nix develop を実行
 ```
@@ -262,7 +271,7 @@ $ lnix search go --version ">=1.20" --json --one
 - `cli_parser.rs`: `Search` サブコマンド追加
 - `main.rs`: search コマンドのハンドリング追加
 - `main.rs`: develop コマンドに version resolution ステップ追加
-- lazynix.yaml への書き戻しロジック追加 (resolvedCommit, resolvedAttr)
+- lazynix.yaml への書き戻しロジック追加 (resolvedCommit, resolvedAttr) (※v0.4 以降廃止)
 
 ### `nix-dispatcher`
 

--- a/document/jp/getting_started.md
+++ b/document/jp/getting_started.md
@@ -245,21 +245,11 @@ devShell:
         version: "1.21.13"
 ```
 
-3. `lnix develop` を実行します。LazyNix は `nix-versions` を呼び出して、そのバージョンに対応する nixpkgs のコミットハッシュと Nix の attribute path を解決し、結果を `resolvedCommit` と `resolvedAttr` として `lazynix.yaml` に書き戻します:
+3. `lnix develop` を実行します。LazyNix は `nix-versions` を呼び出して、そのバージョンに対応する nixpkgs のコミットハッシュと Nix の attribute path を解決し、解決したコミットを生成される `flake.nix` の入力 URL に埋め込みます。以降の実行はその `flake.nix` を直接読むため、`nix-versions` の呼び出しは (name, version) の組ごとに最大 1 回で済みます。`lazynix.yaml` 自体には手を加えません — `flake.nix` **こそがキャッシュ**です。
 
-```yaml
-devShell:
-  package:
-    pinned:
-      - name: go
-        version: "1.21.13"
-        resolvedCommit: "5ed6275"
-        resolvedAttr: "go_1_21"
-```
+チームの誰もが正確に Go 1.21.13 を手に入れます。ネットワーク参照の繰り返しもドリフトも起こりません。
 
-一度解決されれば、以降の実行はキャッシュされた解決結果を再利用します。ネットワーク参照の繰り返しもドリフトもありません。チームの誰もが正確に Go 1.21.13 を手に入れます。
-
-> **補足:** `lnix lint` は `stable`・`unstable`・`pinned` のすべてのパッケージを検証します。`pinned` エントリで `resolvedCommit` / `resolvedAttr` が `lazynix.yaml` にまだキャッシュされていない場合、`lint` は `nix-versions` に問い合わせて指定されたバージョンが現在も解決可能かも確認します。バージョン指定のタイプミスは次の `lnix develop` を待たずにここで検出されます。
+> **補足:** `lnix lint` は `stable`・`unstable`・`pinned` のすべてのパッケージを検証します。`pinned` エントリごとに `lint` は `nix-versions` へ問い合わせて指定されたバージョンが現在も解決可能かを確認します。バージョン指定のタイプミスは次の `lnix develop` を待たずにここで検出されます。
 
 ## 利用可能なバージョンを検索する
 
@@ -329,7 +319,7 @@ devShell:
 - `lnix develop` で環境に入った
 - `lnix run` でコマンドを実行し、再利用可能なタスクを定義した
 - `lnix lint` で設定を検証した
-- `devShell.package.pinned` で個別のパッケージを特定バージョンへ固定し、LazyNix に `resolvedCommit` と `resolvedAttr` を書き込ませた
+- `devShell.package.pinned` で個別のパッケージを特定バージョンへ固定し、解決された nixpkgs コミットを LazyNix に `flake.nix` へ埋め込ませた
 - `lnix search` で利用可能なバージョンを検索した
 - `lnix update` で `flake.lock` の更新だけを行った
 - `devShell.shellAlias` で外部ファイルからシェルエイリアスを読み込んだ

--- a/document/jp/system_architecture.md
+++ b/document/jp/system_architecture.md
@@ -48,7 +48,7 @@ crates/
 
 `flake.nix` を生成するユースケース (`develop` / `test` / `run`) は、`pipeline.rs` に定義された共通の前段を共有します:
 
-1. `load_config` — 設定ファイル (settings) の読み込み、`lazynix.yaml` の読み込み、`validate_config` の実行 (診断は `OutputPort::warn` に流す)、参照される dotenv ファイルの存在チェック、pinned パッケージの解決とその結果の `lazynix.yaml` への書き戻し。
+1. `load_config` — 設定ファイル (settings) の読み込み、`lazynix.yaml` の読み込み、`validate_config` の実行 (診断は `OutputPort::warn` に流す)、参照される dotenv ファイルの存在チェック、pinned パッケージの解決。解決結果は生成される `flake.nix` に埋め込まれ、`lazynix.yaml` は書き換えません。再実行時は `FlakeReader` ポート経由で `flake.nix` から `(commit, attr)` を復元し、キャッシュヒット時は resolver 呼び出しをスキップします。
 2. `write_flake` — `lnix_domain::render_flake` を呼び出し、結果を `./flake.nix` に書き込む。
 3. `maybe_update_lock` — `--update` が指定されているときのみ `NixRunner::flake_update` を呼び出す。
 
@@ -115,7 +115,7 @@ DevShellDefinition
 
 新しめのフィールドに関する補足:
 
-- `pinned` はパッケージを厳密なバージョンに固定します。`resolvedCommit` と `resolvedAttr` は、パイプラインが `VersionResolver` 経由で初めて解決した際に埋められ、以降の実行で再解決を避けるために `lazynix.yaml` に書き戻されます。
+- `pinned` はパッケージを厳密なバージョンに固定します。パイプラインは `VersionResolver` 経由で一度解決した `(commit, attr)` を生成後の `flake.nix` へ埋め込み、それが真実の情報源になります。`lazynix.yaml` は書き換えません。次回以降の実行は `FlakeReader` ポート経由で `flake.nix` から `(commit, attr)` を読み戻します。旧仕様の `resolvedCommit` / `resolvedAttr` フィールドは互換のため読み込みは受理しますが、シリアライズはされません。
 - `shellAlias` は、シェルエイリアスの定義を開発シェルへロードする対象ファイルの一覧です。
 - `env.envvar[].name` は `EnvVarName`、`task` のキーは `TaskName` の値オブジェクトで、不正な識別子は YAML パース時点で拒否されます。
 
@@ -152,8 +152,10 @@ DevShellDefinition
        ├── ConfigRepository::read_config           (lazynix.yaml → DevShellDefinition)
        ├── lnix_domain::validate_config            (診断 → OutputPort::warn)
        ├── validate_env_files                      (dotenv ファイルの存在確認)
-       └── resolve_pinned_packages                 (VersionResolver::resolve →
-                                                    lazynix.yaml への書き戻し)
+       └── resolve_pinned_packages                 (FlakeReader::read_pinned_inputs
+                                                    がヒットすれば再利用、そうでなければ
+                                                    VersionResolver::resolve。
+                                                    lazynix.yaml は書き換えない)
   │
   4. lnix_app::pipeline::write_flake
        └── lnix_domain::render_flake → FlakeWriter::write_flake

--- a/examples/pinned/README.md
+++ b/examples/pinned/README.md
@@ -40,14 +40,15 @@ nix run github:shunsock/lazynix -- search go -v '>=1.21,<1.22'
 nix run github:shunsock/lazynix -- develop
 ```
 
-## Note: Write-back Behavior
+## Note: Resolution Caching
 
-When you invoke `lnix develop` for the first time, `lazynix` uses
+When you invoke `lnix develop` and no `flake.nix` exists, `lazynix` uses
 [`nix-versions`](https://lazamar.github.io/download-specific-package-version-with-nix/)
 to look up the exact nixpkgs commit that provides the requested version, then
-writes the resolved metadata back into `lazynix.yaml` as `resolvedCommit` and
-`resolvedAttr`. Subsequent runs reuse those values, so the pin is reproducible
-even if the upstream index changes.
+embeds that commit into the generated `flake.nix` as its input URL. Subsequent
+runs reuse the commit baked into `flake.nix` and skip the resolver call, so
+the pin remains reproducible even if the upstream index changes.
+`lazynix.yaml` is never mutated.
 
 ## References
 

--- a/examples/pinned/lazynix.yaml
+++ b/examples/pinned/lazynix.yaml
@@ -2,18 +2,12 @@ devShell:
   allowUnfree: true
   package:
     stable:
-    - name: python312
-    - name: uv
+      - name: python312
+      - name: uv
     unstable: []
     pinned:
-    - name: go
-      version: 1.21.13
-      resolvedCommit: 5ed6275
-      resolvedAttr: go_1_21
+      - name: go
+        version: "1.21.13"
   shellHook:
-  - echo Python $(python --version) ready!
-  - echo Go $(go version) ready!
-  env: null
-  test: []
-  task: null
-  shellAlias: []
+    - "echo Python $(python --version) ready!"
+    - "echo Go $(go version) ready!"


### PR DESCRIPTION
## 概要

`pinned` パッケージの `(commit, attr)` キャッシュを `lazynix.yaml` から `flake.nix` へ寄せ、二重 SSoT を解消する。`resolve_pinned_packages` は生成済み `flake.nix` から (commit, attr) を復元して再利用し、`lazynix.yaml` への書き戻しは廃止する。加えてレビュー指摘 43 件を反映した。

Closes #69

**この PR は [#68](https://github.com/shunsock/lazynix/pull/68) の上に stack しています** (base: `worktree-docs-v0.3.0`)。#68 が main にマージされたら base が自動的に main へ書き換わります。

## 背景

Issue #57 (PR #68) 実装中の会話で「`resolvedCommit` / `resolvedAttr` は必須?」というユーザー疑問から始まった。実装を辿ると、`crates/lnix-app/src/pipeline.rs::resolve_pinned_packages` が `nix-versions` 呼び出しの結果を `lazynix.yaml` へ書き戻していた (`d.repo.write_config`)。しかし同じ `(commit, attr)` は既に `flake.nix` の入力宣言に埋め込まれている:

```nix
inputs = {
  nixpkgs--go--1-21-13.url = "github:NixOS/nixpkgs/5ed6275";
};
```

つまり `(commit, attr)` は `lazynix.yaml` (キャッシュ) と `flake.nix` (入力宣言) の両方に同時に存在する **二重 SSoT** で、`lazynix.yaml` は事実上重複キャッシュとして機能していた。

## 課題

- **二重 SSoT**: 同じ事実が 2 箇所に存在。片方を手で編集すると挙動が読みにくくなる
- **ユーザー可視領域の汚染**: `PinnedPackageEntry` 4 フィールドのうち 2 つが auto-generated だが `examples/pinned/lazynix.yaml` に露出しており「これは自分で書くのか」の混乱が生じた (実際にレビューで指摘された)
- **書き戻しが暗黙**: `lnix develop` / `lnix generate` を実行するとユーザーが編集していない `lazynix.yaml` が書き換わり、git status に予期しない diff が現れる
- **CI との癒着**: `.github/workflows/verify_examples_sync.yml` が `git diff --exit-code` で厳格に一致検証するため、`examples/*/lazynix.yaml` を write-back 済みの姿でコミットしなければ CI が落ちていた (設計判断ではなく実装の副作用に CI が縛られていた)
- **ドキュメントの矛盾**: PR #68 で追加した `README.md` / `getting_started.md` は「`lint` が `pinned` を検証する」と書いていたが、実際の `verify_pinned_versions` は `resolvedCommit` が入っていると早期 `continue` して resolver 検証をスキップしていた

## 目標

### 必須項目

- `lnix develop` / `lnix generate` / `lnix lint` の実行で `lazynix.yaml` が書き換わらない
- `PinnedPackageEntry` の schema からユーザーが書かない `resolvedCommit` / `resolvedAttr` が serialize されなくなる (deserialize は backwards-compat で許容)
- 再実行時に `nix-versions` を無駄に叩かない (現行のパフォーマンス特性を維持)
- `.github/workflows/verify_examples_sync.yml` が例のコミット済み `lazynix.yaml` に対しても diff-free で回る
- `lint` は常に `pinned` バージョンを resolver で再検証する (README/getting_started の記述と実装を一致させる)

### 範囲外

- **JSON 出力 / TUI / i18n**: presentation 層の話は PR #70 (`UseCaseEvent` + `ReporterPort`) が担当
- **`FlakeReader` の OOM cap / duplicate detection / commit hash validation**: バグレビューで指摘されたが実運用でほぼ発生しないため follow-up issue
- **`lnix` bin crate / `lnix-app` crate の rename** (`lnix-cli` / `lnix-usecase`): ユーザーから提案されたが、3 PR (#68/#69/#70) の merge 後に単独 PR で対応する方針

## 採用手法

案 B「`flake.nix` があればそこから previous `(commit, attr)` を復元、無ければ resolver」を採用。Issue #69 で検討した 4 案の比較:

| 案 | 長所 | 短所 | 採否 |
|----|------|------|------|
| A: 現状維持 (`lazynix.yaml` に書き戻し) | 実装コスト 0 | 二重 SSoT。UX 悪化 | 不採用 |
| B: `flake.nix` から復元、なければ resolver | 単一 SSoT。既存性能を維持 | flake.nix のミニパーサが必要 | **採用** |
| C: 常に resolver を叩き cache しない | 実装が最も単純 | 毎 `lnix develop` で `nix run github:vic/nix-versions` を起動。オフラインで完全に詰む | 不採用 |
| D: `flake.lock` を SSoT にする | Nix 本来の仕組みに乗る | `flake.lock` 生成前 (`--update` 未実行) には commit を知りようがない | 不採用 |

### 採用理由

案 A / C は SSoT を解決しない / 性能を捨てる。案 D は `lnix generate` をオフラインで走らせたい設計 (README でも訴求) と矛盾する。案 B は初期コストとして `flake.nix` のミニパーサを書く必要があるが、writer 側 (`crates/lnix-domain/src/service/flake/pinned.rs`) と reader 側で共通 const を共有することで同期を保証できる。

### データフロー

```mermaid
flowchart LR
  YAML[lazynix.yaml<br/>name + version] --> Pipeline[resolve_pinned_packages]
  ExistingFlake[flake.nix<br/>SSoT] --> FlakeReader
  FlakeReader -->|cache hit| Pipeline
  Pipeline -->|cache miss| Resolver[nix-versions]
  Resolver --> Pipeline
  Pipeline --> Render[render_flake]
  Render --> NewFlake[flake.nix<br/>regenerated]
```

`lazynix.yaml` への矢印は無い (書き戻しなし)。`(commit, attr)` は必ず `flake.nix` を経由する。

## 変更箇所

新規 (2 files):
- `crates/lnix-domain/src/interface/persistence/flake_reader.rs`: `FlakeReader` port trait + `PinnedResolution` / `PinnedResolutions` 型。
- `crates/lnix-infra/src/persistence/flake_reader.rs`: `FsFlakeReader` adapter。writer 側の共通 const (`PINNED_INPUT_PREFIX` / `PINNED_INPUT_URL_SUFFIX` / `PINNED_BINDING_PREFIX` / `PINNED_URL_COMMIT_PREFIX`) を使って `flake.nix` を parse。7 unit test。

変更 (Rust):
- `crates/lnix-app/src/pipeline.rs`: `resolve_pinned_packages` を SSoT 復元パターンへ書き換え。`d.repo.write_config` の呼び出しを削除。6 unit test 追加。
- `crates/lnix-app/src/deps.rs`: `flake_reader` port を配線。`writer` → `flake_writer` にリネームして `flake_reader` と対称化。
- `crates/lnix-app/src/mocks.rs`: `MockFlakeReader` を追加、`Mocks::with_flake_reader` / `with_failing_flake_reader` を提供。`MockRepo::persisted_config` を削除 (write_config 削除に追従)。
- `crates/lnix-app/src/usecase/{develop,generate,run,test,lint}.rs`: `writer` → `flake_writer` の呼び出し名変更、および `lint::verify_pinned_versions` の早期 `continue` 削除。
- `crates/lnix-domain/src/definition/package.rs`: `PinnedPackageEntry::resolved_commit` / `resolved_attr` に `#[serde(skip_serializing)]` を付与。5 unit test 追加 (serialize omission / round-trip drops / backwards-compat deserialize)。
- `crates/lnix-domain/src/error.rs`: `FlakeError::Read(io::Error)` variant を追加。`#[from]` は `Write` variant にのみ付ける (thiserror が同一 source 型に 2 度 impl できないため) 旨を doc 化。
- `crates/lnix-domain/src/interface/persistence/config_repository.rs`: `write_config` を trait から **削除** (production 呼び出しが消失)。
- `crates/lnix-domain/src/service/flake/pinned.rs`: `PINNED_INPUT_PREFIX` / `PINNED_INPUT_URL_SUFFIX` / `PINNED_BINDING_PREFIX` / `PINNED_URL_COMMIT_PREFIX` を pub const として提供。reader/writer で共有。
- `crates/lnix-domain/src/values/package_name.rs`: `--` 連続を禁止 (writer の区切りと衝突するため)。
- `crates/lnix-infra/src/persistence/config_repository.rs`: `FsConfigRepository::write_config` を削除。
- `crates/lnix-infra/tests/yaml_template_test.rs`: `yaml_template_describes_flake_embedding_not_write_back` 新規テスト。
- `crates/lnix/src/composition.rs`: `FsFlakeReader` を `AdapterSet` に配線。

変更 (docs / templates):
- `crates/lnix-infra/templates/lazynix.yaml.template`: `# resolvedCommit / resolvedAttr are filled in automatically and written back` の行を「the resolved nixpkgs commit is embedded in the generated flake.nix / this file stays untouched」に書き換え。
- `README.md`: Version Pinning 節から write-back 記述と `resolvedCommit` の登場を削除。Exit Codes 節の `lint` 記述を「pinned もチェック」に更新。
- `document/{en,jp}/getting_started.md`: Pinning 節の write-back Note を「`flake.nix` を再生成する」旨に変更。
- `document/{en,jp}/system_architecture.md`: write-back を前提としていた記述を SSoT 型に書き換え。
- `document/jp/design/version-pinning.md`: 「以下は v1.0.0 (廃止) 仕様」の冒頭注記と、write-back に関する記述への「※v0.4 以降廃止」括弧書きを追加。詳細本文は歴史的記録として保持。
- `examples/pinned/lazynix.yaml`: 「ユーザーが手で書く形」に戻す (`resolvedCommit` / `resolvedAttr` / `env: null` / `test: []` / `task: null` / `shellAlias: []` を削除)。
- `examples/pinned/README.md`: 「Write-back Behavior」節を「Resolution Caching」に改題し、`flake.nix` 埋め込みの説明に更新。

## 妥協と制限

- **pre-release version は cache 対象外**: `1.0.0-rc1` のような pre-release は writer 側の `.` → `-` 正規化が可逆でないためキャッシュミスする (毎回 resolver 呼び出し)。実害は速度のみ。`resolve_pinned_packages` で警告を出す + design 文書に注記。将来 `_dot_` エスケープ等での可逆化を検討する余地あり (別 issue)
- **旧 yaml の backwards-compat**: `resolvedCommit` / `resolvedAttr` 入りの `lazynix.yaml` を deserialize してもエラーにならない (serde default で受理、以後 serialize されないので自然に "clean shape" にマイグレートされる)
- **`FlakeReader` の robustness**: OOM cap / 重複キーの警告 / commit hash 形式検証は未実装 (現実的な pinned 数では問題なし。写経の悪意ある改変は writer が生成する形式に限られ、脆弱性面は無し)
- **`lint` は毎回 resolver を叩く**: 意図された動作 (「バージョンが今も解決可能か」を検証するのが lint の目的)。オフライン環境では `lint` 失敗するが `develop` は cache 経由で成功する

## 検証方法

Phase 3 のレビュー (readability / consistency / bug_checker / complexity) 4 種を実施し、48 findings 中 43 件を反映済。5 件は妥協理由付きで残置 (PR 本体で列挙)。

- `nix develop -c cargo test --workspace`: 242 pass / 0 fail / 7 ignored
- `nix develop -c cargo fmt --all --check`: clean
- `nix develop -c cargo clippy --workspace --tests -- --deny warnings`: clean
- `nix develop -c cargo build --release -p lnix`: 成功
- `bash scripts/verify-doc-yaml.sh`: exit 0
- `bash .github/scripts/verify_examples_sync.sh`: exit 0 (`examples/pinned/lazynix.yaml` を name+version-only に戻しても再生成で diff が出ない)
- 手動 idempotency: `rm examples/pinned/flake.nix && lnix -C examples/pinned generate` → `git diff examples/pinned/lazynix.yaml` が空
- backwards-compat: 旧形式 (`resolvedCommit`/`resolvedAttr` 入り) の yaml を deserialize → serialize → deserialize で resolved fields が None に落ちる (`round_trip_drops_resolved_fields` テストで検証)

## 確認事項

- ⚠️ **`ConfigRepository::write_config` の削除**: production 呼び出しが消失したため port method 自体を削除しました。将来 (例えば `lnix migrate` サブコマンド) `lazynix.yaml` を書き戻す use-case が生まれる際は復活検討が必要です。
- ⚠️ **`Deps::writer` → `Deps::flake_writer` の rename**: `flake_reader` と対称化する狙い。既存 use-case テスト・composition root も追随済。命名変更は API 表面積の破壊的変更ですが、この PR の 43 review findings 反映のうち Consistency #8 として提案された内容です。
- ⚠️ **`PackageName` の invariant 拡張**: `--` 連続を禁止しました。既存の valid な名前 (`python312` / `rust-analyzer` / `python312Packages.pip` 等) は影響を受けませんが、ユーザーが `foo--bar` のような名前を書いていた場合は break します。実運用では nixpkgs にそのような名前はほぼ存在しません。
- ⚠️ **pre-release version の cache 除外**: `1.0.0-rc1` のような pre-release は cache が効きません (毎回 resolver 呼び出し)。この spec 変更の是非を確認してください。可逆エスケープ導入は将来検討。
- ⚠️ **`document/jp/design/version-pinning.md` の扱い**: 詳細本文は歴史的記録として保持し、冒頭注記のみ追加しました。書き換え or 削除の方針でよいかご判断ください。

## 参考文献

- [Issue #69](https://github.com/shunsock/lazynix/issues/69) — 本 PR の対象 Issue (PR #68 レビュー時に発掘された設計課題)
- [PR #68](https://github.com/shunsock/lazynix/pull/68) — この PR の base。#68 マージ後に本 PR の base は自動で main へ切り替わる
- [PR #70](https://github.com/shunsock/lazynix/pull/70) — presentation 層の refactor (UseCaseEvent / ReporterPort)。scope は分離しているが `lnix-app` に触れるため merge 順序に注意
- [PR #17](https://github.com/shunsock/lazynix/pull/17) — `pinned` と write-back 挙動を導入した PR
- [PR #63](https://github.com/shunsock/lazynix/pull/63) — `lnix lint` が pinned を含めるようになった PR。本 PR の Bug #2 修正 (早期 continue 削除) はここの意図と一致させる
- [document/jp/design/version-pinning.md](https://github.com/shunsock/lazynix/blob/main/document/jp/design/version-pinning.md) — バージョン固定の設計文書 (本 PR で「以下は v1.0.0 (廃止) 仕様」注記を追加)
- [nix-versions](https://github.com/vic/nix-versions) — `pinned` / `lnix search` が依存する外部ツール
